### PR TITLE
add a few more paths to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.pptx
 
 # notebook stuff
+Untitled*.ipynb
 *.ipynb_checkpoints/
 
 # misc files
@@ -40,10 +41,10 @@
 
 # data files
 *.csv
+*.dat
 *.data
 *.db
 *.feather
-*.json
 *.ndjson
 *.npy
 *.parquet
@@ -68,3 +69,8 @@ prefect-fork/*
 # editor files
 **/.idea/
 **/.vscode/
+
+# key material
+*.pem
+*rsa
+*.pub


### PR DESCRIPTION
More trying to break #2 into small pieces. This PR adds a few more paths to `.gitignore` for safety. It also removes `.json` from that file, since we'll soon be adding `saturn.json` as part of the spec.