### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# This file controls default reviewers for examples/ code.
+# See https://help.github.com/en/articles/about-code-owners
+# for details
+#
+# Maintainers are encouraged to use their best discretion in
+# setting reviewers on PRs manually, but this file should
+# offer a reasonable automatic best-guess
+
+# catch-all rule (this only gets matched if no rules below match)
+*    @rikturr @jameslamb @jsignell
+
+.github/*    @jameslamb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 This document describes how to contribute to `saturncloud/examples`.
 
+When you add a new example, add an entry to [`CODEOWNERS`](./.github/CODEOWNERS) to be sure you'll be added as a reviewer on future updates to it.
+
 ## `examples/` Directory Structure
 
 Examples in this the `examples/` directory follow a specific directory structure that allows Saturn to automatically seed them in a new user's environment with these.


### PR DESCRIPTION
This PR proposes adding a CODEOWNERS file, so that every pull request will automatically be assigned a reviewer.

This file also allows us to handle ownership of different sections without anyone needing to "just know" things like "@rikturr did the nyc-taxi stuff".

I definitely believe that @rikturr should be on every PR here. @jsignell I assumed you'd want to be, but let me know if you want me to take you off the catch-all rule.