### PR TITLE
add validation on saturn.json

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -37,5 +37,5 @@ jobs:
         if: matrix.task == 'validating-examples'
         shell: bash
         run: |
-          pip install --upgrade requests
+          pip install --upgrade marshmallow requests
           make validate

--- a/examples/examples-cpu/.saturn/saturn.json
+++ b/examples/examples-cpu/.saturn/saturn.json
@@ -1,11 +1,11 @@
 {
     "image": "saturncloud/saturn:2020.07.08.1",
     "jupyter": {
-        "disk_space": 5.0,
-        "ssh_enabled": null
+        "size": "8xlarge",
+        "disk_space": "256Gi",
+        "ssh_enabled": false
     },
     "environment_variables": {
         "TAXI_S3": "s3://saturn-titan/nyc-taxi"
-    },
-    "extra-field": "it is I, the extra field"
+    }
 }

--- a/examples/examples-cpu/.saturn/saturn.json
+++ b/examples/examples-cpu/.saturn/saturn.json
@@ -1,11 +1,11 @@
 {
     "image": "saturncloud/saturn:2020.07.08.1",
     "jupyter": {
-        "size": "8xlarge",
-        "disk_space": "256Gi",
-        "ssh_enabled": false
+        "disk_space": 5.0,
+        "ssh_enabled": null
     },
     "environment_variables": {
         "TAXI_S3": "s3://saturn-titan/nyc-taxi"
-    }
+    },
+    "extra-field": "it is I, the extra field"
 }


### PR DESCRIPTION
This PR adds validation on the contents of `saturn.json`. Using `marshmallow`, the validation code should now catch all of these:

* required field is missing
* required field is present, but has wrong type
* required field is present, but null
* unknown extra field added

I intentionally introduced all these problems into `examples-cpu/.saturn/saturn.json` just so we can confirm that the GitHub Actions job fails and gives a meaningful error. I'll revert those changes before merging.