### PR TITLE
add logos to Prefect example and fix links

### DIFF
--- a/examples/examples-cpu/prefect/README.md
+++ b/examples/examples-cpu/prefect/README.md
@@ -1,3 +1,5 @@
 # prefect-scheduled-scoring
 
-The files in this directory were created to support ["Using a scheduled prefect flow with a Saturn Dask cluster"](http://docs.saturncloud.io/en/articles/4135965-using-a-scheduled-prefect-flow-with-a-saturn-dask-cluster)
+The files in this directory were created to support these articles:
+
+  * ["Scheduled Data Pipelines"](https://www.saturncloud.io/docs/deployments/data-pipelines)

--- a/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
@@ -6,6 +6,17 @@
    "source": [
     "## Scheduled Scoring with Prefect on Saturn Cloud\n",
     "\n",
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://docs.dask.org/en/latest/_images/dask_horizontal.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"https://dask.org/_images/prefect-logo.svg\" width=\"150\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>\n",
+    "\n",
     "This notebook contains sample code to take a `prefect` flow and distribute its work with a `Dask` cluster. The flow below mocks the process of measuring the effectiveness of a deployed statistical model.\n",
     "\n",
     "### Model Details\n",
@@ -371,7 +382,7 @@
     "\n",
     "Using `flow.run()` in a notebook is excellent for testing, but once you are confident that this code is doing what you expect, you will probably want to run it in an automated, isolated environment.\n",
     "\n",
-    "Return to [\"Using a scheduled prefect flow with a Saturn Dask cluster\"]() to see how to take the code we've developed and run it as **Custom Deployment** in Saturn Cloud."
+    "Return to [\"Scheduled Data Pipelines\"](https://www.saturncloud.io/docs/deployments/data-pipelines/) to see how to take the code we've developed and run it as **Custom Deployment** in Saturn Cloud."
    ]
   }
  ],


### PR DESCRIPTION
This fixes a few small issues with the Prefect example:

* fixes link in README
* fills in empty link in `prefect-scheduled-scoring.ipynb`
* adds logos to `prefect-scheduled-scoring.ipynb` to make them as pretty as the other notebooks

![image](https://user-images.githubusercontent.com/7608904/91614638-8619a980-e947-11ea-8d7a-2e539ec152d7.png)
