### PR TITLE
use cluster_class instead of address for Dask executor

### DIFF
--- a/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
@@ -326,17 +326,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cluster = SaturnCluster()\n",
-    "cluster.scale(2)\n",
-    "cluster"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -352,7 +341,7 @@
    "outputs": [],
    "source": [
     "executor = DaskExecutor(\n",
-    "    address=cluster.scheduler_address\n",
+    "    cluster_class=SaturnCluster\n",
     ")"
    ]
   },

--- a/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-scheduled-scoring.ipynb
@@ -341,7 +341,8 @@
    "outputs": [],
    "source": [
     "executor = DaskExecutor(\n",
-    "    cluster_class=SaturnCluster\n",
+    "    cluster_class=SaturnCluster,\n",
+    "    adapt_kwargs={\"minimum\": 2, \"maximum\": 2}\n",
     ")"
    ]
   },
@@ -391,7 +392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
use `DaskExecutor(cluster_class=SaturnCluster)` to match [docs page](https://www.saturncloud.io/docs/deployments/data-pipelines/#multi-node-cluster)