### PR TITLE
remove prefect install from examples-cpu start script

### DIFF
--- a/examples/examples-cpu/.saturn/start
+++ b/examples/examples-cpu/.saturn/start
@@ -1,4 +1,0 @@
-pip install \
-    --upgrade \
-        "prefect>0.13.0" \
-        "prefect-saturn>=0.1.0"


### PR DESCRIPTION
`prefect` and `prefect-saturn` will be part of the default image for now (https://github.com/saturncloud/images/pull/70)