### PR TITLE
always run CI everywhere

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -2,13 +2,7 @@ name: Continuous Integration
 
 # only run this workflow on new commits to main
 # or PRs into main
-on:
-  push:
-    branches:
-    - main
-  pull_request:
-    branches:
-    - main
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -1,8 +1,7 @@
 name: Continuous Integration
 
-# only run this workflow on new commits to main
-# or PRs into main
-on: [push]
+# alwas run CI on new commits to any branch
+on: push
 
 jobs:
   test:


### PR DESCRIPTION
Noticed on #18 that CI jobs aren't running on PRs into release branches. When this repo was created, we didn't have a notion of "release branches", and I set the CI up to only run on commits to `main`.

This change will just make it run anytime any code is pushed anywhere in the repo.