### PR TITLE
fix column names in taxi model serving file

### DIFF
--- a/examples/examples-cpu/nyc-taxi/model-api.py
+++ b/examples/examples-cpu/nyc-taxi/model-api.py
@@ -20,8 +20,8 @@ features = [
     "pickup_week_hour",
     "pickup_minute",
     "passenger_count",
-    "PULocationID",
-    "DOLocationID",
+    "pickup_taxizone_id",
+    "dropoff_taxizone_id",
 ]
 
 


### PR DESCRIPTION
The `examples-cpu/nyc-taxi/model_api.py` was referring to old column names. #16 already fixes this but it needs to go out with the `2020.08.28` release as well