### PR TITLE
Convert prefect notebook to one-shot

### DIFF
--- a/examples/examples-cpu/prefect/prefect-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-scoring.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Scheduled Scoring with Prefect on Saturn Cloud\n",
+    "## Scoring with Prefect on Saturn Cloud\n",
     "\n",
     "<table>\n",
     "    <tr>\n",
@@ -62,7 +62,6 @@
     "from io import BytesIO\n",
     "from prefect import task, Parameter, Task, Flow\n",
     "from prefect.engine.executors.dask import DaskExecutor\n",
-    "from prefect.schedules import IntervalSchedule\n",
     "from sklearn.metrics import mean_absolute_error\n",
     "from sklearn.metrics import median_absolute_error\n",
     "from sklearn.metrics import mean_squared_error\n",
@@ -227,9 +226,7 @@
     "\n",
     "> * A graph is a data structure that uses \"edges\" to connect \"nodes.\" Prefect models each Flow as a graph in which Task dependencies are modeled by Edges.\n",
     "> * A directed graph means that edges have a start and an end: when two tasks are connected, one of them unambiguously runs first and the other one runs second.\n",
-    "> * An acyclic directed graph has no circular dependencies: if you walk through the graph, you will never revisit a task you've seen before.\n",
-    "\n",
-    "Because we want this job to run on a schedule, the code below provides one additional argument to `Flow()`, a special \"schedule\" object. In this case, the code below says \"run this flow every 10 minutes\"."
+    "> * An acyclic directed graph has no circular dependencies: if you walk through the graph, you will never revisit a task you've seen before."
    ]
   },
   {
@@ -238,25 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schedule = IntervalSchedule(\n",
-    "    interval=timedelta(minutes=10)\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*NOTE: `prefect` flows do not have to be run on a schedule. To test a single run, just omit `schedule` from the code block below.*"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "with Flow('ticket-model-evaluation', schedule=schedule) as flow:\n",
+    "with Flow('ticket-model-evaluation') as flow:\n",
     "    batch_size = Parameter(\n",
     "        'batch-size',\n",
     "        default=1000\n",
@@ -350,7 +329,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, run the flow! The code below will pass all of the tasks to the `Dask` cluster you created above. Because `flow` was defined with an `IntervalSchedule`, it will run continuously, and will re-run all the tasks every minute."
+    "Finally, run the flow! The code below will pass all of the tasks to the `Dask` cluster you created above."
    ]
   },
   {
@@ -359,9 +338,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flow.run(\n",
-    "    executor=executor\n",
-    ")"
+    "flow.run(executor=executor)"
    ]
   },
   {
@@ -372,7 +349,7 @@
     "\n",
     "Using `flow.run()` in a notebook is excellent for testing, but once you are confident that this code is doing what you expect, you will probably want to run it in an automated, isolated environment.\n",
     "\n",
-    "Return to [\"Scheduled Data Pipelines\"](https://www.saturncloud.io/docs/deployments/data-pipelines/) to see how to take the code we've developed and run it as **Custom Deployment** in Saturn Cloud."
+    "Return to [\"Scheduled Data Pipelines\"](https://www.saturncloud.io/docs/deployments/data-pipelines/) to see how to take the code we've developed and run it as a **Scheduled Deployment** in Saturn Cloud."
    ]
   }
  ],


### PR DESCRIPTION
Removing the scheduling components from the non-cloud prefect example. This will allow it to be used for creating a scheduled deployment instead, and for integration-tests as a one-shot.