### PR TITLE
Update examples images

### DIFF
--- a/examples/examples-cpu/.saturn/saturn.json
+++ b/examples/examples-cpu/.saturn/saturn.json
@@ -1,5 +1,5 @@
 {
-    "image": "saturncloud/saturn:2020.09.25",
+    "image": "saturncloud/saturn:2020.10.23",
     "jupyter": {
         "size": "large",
         "disk_space": "10Gi",

--- a/examples/examples-gpu/.saturn/saturn.json
+++ b/examples/examples-gpu/.saturn/saturn.json
@@ -1,5 +1,5 @@
 {
-    "image": "saturncloud/saturn-gpu:2020.09.25",
+    "image": "saturncloud/saturn-gpu:2020.10.23",
     "jupyter": {
         "size": "g4dnxlarge",
         "disk_space": "10Gi",


### PR DESCRIPTION
Updating images in the example notebooks to latest. Primarily because there's a bug in the prefect CLI that was causing me issues in the integration-tests (fixed in the version installed in 10.23), but also it's a good idea to update these in general.

Have not tested the examples on this image yet, will do that.