### PR TITLE
wait with Client.wait_for_workers()

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -85,10 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -388,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -385,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -365,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -94,10 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -368,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
+++ b/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
@@ -82,10 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -472,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
+++ b/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
@@ -469,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -84,10 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -307,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -304,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -297,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -88,10 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -300,7 +297,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/snowflake/snowflake-dask.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-dask.ipynb
@@ -135,10 +135,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -397,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/snowflake/snowflake-dask.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-dask.ipynb
@@ -394,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -112,10 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -406,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -403,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
@@ -323,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
@@ -111,10 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "while len(client.scheduler_info()['workers']) < n_workers:\n",
-    "    print('Waiting for workers, got', len(client.scheduler_info()['workers']))\n",
-    "    time.sleep(30)\n",
-    "print('Done!')"
+    "client.wait_for_workers(n_workers=n_workers)"
    ]
   },
   {
@@ -326,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some of the notebooks in this project use `dask-saturn` to create a Dask cluster, and have custom code to block execution until all the requested workers are up.

This PR proposes replacing that custom code with the official method already provided by `distributed`: `Client.wait_for_workers()`.

This change simplifies the examples a bit and makes better use of existing methods from Dask. I think this is important because it eliminates a place where users might look at that custom code and feel like "wow Dask is kind of hard to work with, it's surprising you have to write your own workaround for this".