### PR TITLE
fix indenting, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Example projects for getting started with Saturn Cloud.
 
 ## Structure
 
-Each example in the `examples/` directory is used to pre-populate a Saturn Cloud project in installations of Saturn Cloud. For details on the structure and guidance on how to edit or add exaamples, see [the contributing guidelines](./CONTRIBUTING.md).
+Each example in the `examples/` directory is used to pre-populate a Saturn Cloud project in installations of Saturn Cloud. For details on the structure and guidance on how to edit or add examples, see [the contributing guidelines](./CONTRIBUTING.md).

--- a/examples/examples-cpu/nyc-taxi-snowflake/dashboard.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/dashboard.ipynb
@@ -413,7 +413,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Construct vizualizations\n",
+    "## Construct visualizations\n",
     "\n",
     "In this dashboard we'll have three tabs. We'll start with one about volume of rides and aggregate fare, then move on to one about tips and finish with a tab that digests the outputs of the Machine Learning algorithms that we've trained to predict fare.\n",
     "\n",

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -320,7 +320,7 @@
    "source": [
     "## Save model\n",
     "\n",
-    "`GridSearchCV` automatically fits the best paramemters to the full data and stores in `best_estimator_`"
+    "`GridSearchCV` automatically fits the best parameters to the full data and stores in `best_estimator_`"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -206,7 +206,7 @@
    "source": [
     "## Save model\n",
     "\n",
-    "`GridSearchCV` automatically fits the best paramemters to the full data and stores in `best_estimator_`"
+    "`GridSearchCV` automatically fits the best parameters to the full data and stores in `best_estimator_`"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/dashboard.ipynb
+++ b/examples/examples-cpu/nyc-taxi/dashboard.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Construct vizualizations\n",
+    "## Construct visualizations\n",
     "\n",
     "In this dashboard we'll have three tabs. We'll start with one about volume of rides and aggregate fare, then move on to one about tips and finish with a tab that digests the outputs of the Machine Learning algorithms that we've trained to predict fare.\n",
     "\n",

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -235,7 +235,7 @@
    "source": [
     "## Save model\n",
     "\n",
-    "`GridSearchCV` automatically fits the best paramemters to the full data and stores in `best_estimator_`"
+    "`GridSearchCV` automatically fits the best parameters to the full data and stores in `best_estimator_`"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "## Save model\n",
     "\n",
-    "`GridSearchCV` automatically fits the best paramemters to the full data and stores in `best_estimator_`"
+    "`GridSearchCV` automatically fits the best parameters to the full data and stores in `best_estimator_`"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -302,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -66,7 +66,12 @@
     "import time\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size='medium', worker_size='large', nthreads=2)\n",
+    "cluster = SaturnCluster(\n",
+    "    n_workers=n_workers,\n",
+    "    scheduler_size='medium',\n",
+    "    worker_size='large',\n",
+    "    nthreads=2\n",
+    ")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -297,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
@@ -24,7 +24,7 @@
     "* set up the appropriate credentials in Saturn\n",
     "* set up a Prefect Cloud agent in Saturn Cloud\n",
     "\n",
-    "Details on these prerequisits can be found in [\"Fault-Tolerant Data Pipelines with Prefect Cloud\"](https://www.saturncloud.io/docs/deployments/fault-tolerant-data-pipelines-with-prefect-cloud).\n",
+    "Details on these prerequisites can be found in [\"Fault-Tolerant Data Pipelines with Prefect Cloud\"](https://www.saturncloud.io/docs/deployments/fault-tolerant-data-pipelines-with-prefect-cloud).\n",
     "\n",
     "The flow below mocks the process of measuring the effectiveness of a deployed statistical model.\n",
     "\n",

--- a/examples/examples-cpu/snowflake/snowflake-dask.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-dask.ipynb
@@ -399,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/snowflake/snowflake-dask.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-dask.ipynb
@@ -115,7 +115,12 @@
     "import time\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size='medium', worker_size='large', nthreads=2)\n",
+    "cluster = SaturnCluster(\n",
+    "    n_workers=n_workers,\n",
+    "    scheduler_size='medium',\n",
+    "    worker_size='large',\n",
+    "    nthreads=2\n",
+    ")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -394,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -407,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -67,7 +67,11 @@
     "from dask_saturn import SaturnCluster\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size='medium', worker_size='g4dnxlarge')\n",
+    "cluster = SaturnCluster(\n",
+    "    n_workers=n_workers,\n",
+    "    scheduler_size='medium',\n",
+    "    worker_size='g4dnxlarge'\n",
+    ")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -371,7 +375,7 @@
    "source": [
     "<br>\n",
     "\n",
-    "Convert to single-GPU DataFrame using `compute()` because the Dask+RAPIDS implementation doesnt yet have `roc_auc_score`"
+    "Convert to single-GPU DataFrame using `compute()` because the Dask+RAPIDS implementation doesn't yet have `roc_auc_score`"
    ]
   },
   {
@@ -403,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
@@ -327,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
@@ -66,7 +66,11 @@
     "from dask_saturn import SaturnCluster\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size='medium', worker_size='g4dnxlarge')\n",
+    "cluster = SaturnCluster(\n",
+    "    n_workers=n_workers,\n",
+    "    scheduler_size='medium',\n",
+    "    worker_size='g4dnxlarge'\n",
+    ")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -291,7 +295,7 @@
    "source": [
     "<br>\n",
     "\n",
-    "Convert to single-GPU DataFrame using `compute()` because the Dask+RAPIDS implementation doesnt yet have `roc_auc_score`"
+    "Convert to single-GPU DataFrame using `compute()` because the Dask+RAPIDS implementation doesn't yet have `roc_auc_score`"
    ]
   },
   {
@@ -323,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR proposes two minor changes.

1. Fixing some small misspellings
2. Using clearer indentation for `SaturnCluster` calls

The choice of parameters to `SaturnCluster` is a really important part of understanding how to work with Dask in Saturn, and I think we should be doing one argument per line so it's easier to see those arguments and their values.

**before**

![image](https://user-images.githubusercontent.com/7608904/98580060-0e3ff780-2285-11eb-94b0-72d433410934.png)


**after**

![image](https://user-images.githubusercontent.com/7608904/98579989-f7010a00-2284-11eb-9aa9-9b9968ba294c.png)
