### PR TITLE
fix GitHub Actions conda setup

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Set up Python 3.7
-        uses: s-weigand/setup-conda@v1.0.3
+        uses: s-weigand/setup-conda@v1
         with:
           python-version: 3.7
       - name: linting


### PR DESCRIPTION
CI for this project is currently breaking because GitHub Actions disabled some features used by one of the actions we use.

https://github.com/saturncloud/examples/pull/41/checks?check_run_id=1413480738

```
Error: Unable to process command '##[add-path]/usr/share/miniconda' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Error: Unable to process command '##[add-path]/usr/share/miniconda/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

This PR tries to fix it by updating to the latest version of the `setup-conda` action.

Anyone can approve this.