### PR TITLE
remove unnecessary imports in examples-gpu notebooks

### DIFF
--- a/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids-dask.ipynb
@@ -131,7 +131,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import dask_cudf\n",
     "\n",
     "taxi = dask_cudf.read_csv(\n",

--- a/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
@@ -54,12 +54,9 @@
    "outputs": [],
    "source": [
     "import cudf\n",
-    "import s3fs\n",
-    "\n",
-    "s3 = s3fs.S3FileSystem(anon=True)\n",
     "\n",
     "taxi = cudf.read_csv(\n",
-    "    s3.open('s3://nyc-tlc/trip data/yellow_tripdata_2019-01.csv', mode='rb'),\n",
+    "    'https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv',\n",
     "    parse_dates=['tpep_pickup_datetime', 'tpep_dropoff_datetime']\n",
     ")"
    ]
@@ -180,7 +177,7 @@
    "outputs": [],
    "source": [
     "taxi_test = cudf.read_csv(\n",
-    "    s3.open('s3://nyc-tlc/trip data/yellow_tripdata_2019-02.csv', mode='rb'),\n",
+    "    'https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-02.csv',\n",
     "    parse_dates=['tpep_pickup_datetime', 'tpep_dropoff_datetime']\n",
     ")\n",
     "\n",


### PR DESCRIPTION
Working through the GPU examples today, I found an unused import of `numpy`, and one place where we could remove an unnecessary dependency on `s3fs` by just using HTTPS to access data files in S3.

I've tested these notebooks on a recent version of Saturn so I'm confident in these changes.