### PR TITLE
Add snowflake logo to snowflake notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -8,7 +8,16 @@
     "\n",
     "## Dask cluster\n",
     "\n",
-    "<img src=\"https://docs.dask.org/en/latest/_images/dask_horizontal.svg\" width=\"400\">"
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://docs.dask.org/en/latest/_images/dask_horizontal.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"300\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
    ]
   },
   {
@@ -382,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -391,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -8,7 +8,16 @@
     "\n",
     "## Single-node scikit-learn\n",
     "\n",
-    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Scikit_learn_logo_small.svg/1200px-Scikit_learn_logo_small.svg.png\" width=\"300\">\n"
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Scikit_learn_logo_small.svg/1200px-Scikit_learn_logo_small.svg.png\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"450\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
    ]
   },
   {
@@ -267,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -276,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -438,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -14,6 +14,9 @@
     "        <td>\n",
     "            <img src=\"https://upload.wikimedia.org/wikipedia/commons/6/69/XGBoost_logo.png\" width=\"300\">\n",
     "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"450\">\n",
+    "        </td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -435,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -6,7 +6,16 @@
    "source": [
     "# XGBoost regression (single-node)\n",
     "\n",
-    "![xgboost](https://upload.wikimedia.org/wikipedia/commons/6/69/XGBoost_logo.png)"
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://upload.wikimedia.org/wikipedia/commons/6/69/XGBoost_logo.png\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"450\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
    ]
   },
   {
@@ -233,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -242,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -404,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -16,6 +16,9 @@
     "        <td>\n",
     "            <img src=\"https://rapids.ai/assets/images/RAPIDS-logo-purple.svg\" width=\"300\">\n",
     "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"300\">\n",
+    "        </td>\n",
     "    </tr>\n",
     "</table>"
    ]
@@ -401,7 +404,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
@@ -257,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
@@ -8,7 +8,19 @@
     "\n",
     "## RAPIDS single GPU\n",
     "\n",
-    "<img src=\"https://rapids.ai/assets/images/RAPIDS-logo-purple.svg\" width=\"400\">"
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://docs.dask.org/en/latest/_images/dask_horizontal.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"https://rapids.ai/assets/images/RAPIDS-logo-purple.svg\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"300\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
    ]
   },
   {
@@ -245,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -248,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -8,7 +8,16 @@
     "\n",
     "## Single-node scikit-learn\n",
     "\n",
-    "<img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Scikit_learn_logo_small.svg/1200px-Scikit_learn_logo_small.svg.png\" width=\"300\">"
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Scikit_learn_logo_small.svg/1200px-Scikit_learn_logo_small.svg.png\" width=\"300\">\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <img src=\"./img/snowflake.png\" width=\"450\">\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
    ]
   },
   {
@@ -239,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR proposes adding the Snowflake logo to Snowflake notebooks, so it's a bit easier to visually tell the difference between those and the non-snowflake ones.

**before**

![image](https://user-images.githubusercontent.com/7608904/103560757-ee404500-4e7d-11eb-96ea-89bc20fb346d.png)

**after**

![image](https://user-images.githubusercontent.com/7608904/103560722-d963b180-4e7d-11eb-8c56-164670e5a58e.png)
