### PR TITLE
update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @rikturr @jameslamb @jsignell
+*    @rikturr @jameslamb @jsignell @skirmer
 
-.github/*    @jameslamb
+.ci/*    @jameslamb @jsignell
+.github/*    @jameslamb @jsignell
+Makefile    @jameslamb @jsignell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @rikturr @jameslamb @jsignell @skirmer
+*    @rikturr @skirmer
 
 .ci/*    @jameslamb @jsignell
 .github/*    @jameslamb @jsignell


### PR DESCRIPTION
The CODEOWNERS for this project was originally set up a while ago, and I think it could be adjusted to reflect the current state of responsibilities.

* makes @skirmer and @rikturr the default reviewers for PRs
* makes @jsignell and myself the default reviewers for automation pieces

The CODEOWNERS is just an educated first guess, and we should still all feel comfortable pulling people in as reviewers directly for specific things.