### PR TITLE
move MODEL_PATH down to where it is first used

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -26,13 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import numpy as np\n",
     "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -336,6 +331,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/elastic_net_dask.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(grid_search.best_estimator_, f)"

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -26,12 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -223,6 +217,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/elastic_net_scikit.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(grid_search.best_estimator_, f)"

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -34,12 +34,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -355,6 +349,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/xgboost_dask.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(booster, f)"

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -24,12 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -189,6 +183,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/xgboost.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(xgb_reg, f)"

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -17,12 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -242,6 +236,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/elastic_net_dask.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(grid_search.best_estimator_, f)"

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
@@ -17,12 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -184,6 +178,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/elastic_net_scikit.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(grid_search.best_estimator_, f)"

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -31,12 +31,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -286,6 +280,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/xgboost_dask.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(booster, f)"

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -15,12 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -157,6 +151,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/xgboost.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(xgb_reg, f)"

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -29,12 +29,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
@@ -29,12 +29,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_weekofyear', \n",
@@ -187,6 +181,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/random_forest_rapids.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(rfc, f)"

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -26,12 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "MODEL_PATH = 'models'\n",
-    "if not os.path.exists(MODEL_PATH):\n",
-    "    os.makedirs(MODEL_PATH)\n",
-    "    \n",
     "numeric_feat = [\n",
     "    'pickup_weekday', \n",
     "    'pickup_hour', \n",
@@ -192,6 +186,11 @@
    "outputs": [],
    "source": [
     "import cloudpickle\n",
+    "import os\n",
+    "\n",
+    "MODEL_PATH = 'models'\n",
+    "if not os.path.exists(MODEL_PATH):\n",
+    "    os.makedirs(MODEL_PATH)\n",
     "\n",
     "with open(f'{MODEL_PATH}/random_forest_scikit.pkl', 'wb') as f:\n",
     "    cloudpickle.dump(rfc, f)"


### PR DESCRIPTION
Similar to #58 , this PR proposes moving this setup code down in the notebooks to the first place it's needed:

```python
import os

MODEL_PATH = 'models'
if not os.path.exists(MODEL_PATH):
    os.makedirs(MODEL_PATH)
```

Today, when you open the example notebooks you're confronted with a title, and then a block of code with no context. I think this could be one of the reasons that people get stuck or feel like they're unsure what to do (see the before and after screenshots in https://github.com/saturncloud/examples/pull/58#issue-548492895). Moving this code down to where it's first needed is a step towards making the notebook floor more like tutorials ("do this, now this, now this").