### PR TITLE
add missing closing 'details' tag

### DIFF
--- a/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
@@ -82,7 +82,9 @@
     "\n",
     "<br>\n",
     "\n",
-    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources."
+    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources.\n",
+    "\n",
+    "</details>"
    ]
   },
   {

--- a/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-rapids.ipynb
@@ -82,7 +82,7 @@
     "\n",
     "<br>\n",
     "\n",
-    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources.\n",
+    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the available resources.\n",
     "\n",
     "</details>"
    ]

--- a/examples/examples-gpu/nyc-taxi/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-scikit.ipynb
@@ -60,7 +60,7 @@
     "\n",
     "<br>\n",
     "\n",
-    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources.\n",
+    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the available resources.\n",
     "\n",
     "</details>"
    ]

--- a/examples/examples-gpu/nyc-taxi/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi/rf-scikit.ipynb
@@ -60,7 +60,9 @@
     "\n",
     "<br>\n",
     "\n",
-    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources."
+    "Whichever option you choose, leave these terminals with the monitoring process running while you work, so you can see how the code below uses the avaiable resources.\n",
+    "\n",
+    "</details>"
    ]
   },
   {


### PR DESCRIPTION
Some notebooks here use the `<details>` tag to introduce collapsible sections. When I added those, I missed a few of the closing `</details>` tags. This PR fixes those.