### PR TITLE
add Dask customization to prefect examples

### DIFF
--- a/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
@@ -41,7 +41,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Environment Setup\n",
+    "<hr>\n",
+    "\n",
+    "## Environment Setup\n",
     "\n",
     "The code in this notebook uses `prefect` for orchestration *(figuring out what to do, and in what order)* and `dask` for execution *(doing the things)*.\n",
     "\n",
@@ -105,7 +107,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define Tasks\n",
+    "<hr>\n",
+    "\n",
+    "## Define Tasks\n",
     "\n",
     "`prefect` refers to a workload as a \"flow\", which comprises multiple individual things to do called \"tasks\". From [the Prefect docs](https://docs.prefect.io/core/concepts/tasks.html):\n",
     "\n",
@@ -240,7 +244,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Construct a Flow\n",
+    "<hr>\n",
+    "\n",
+    "## Construct a Flow\n",
     "\n",
     "Now that all of the task logic has been defined, the next step is to compose those tasks into a \"flow\". From [the Prefect docs](https://docs.prefect.io/core/concepts/flows.html):\n",
     "\n",
@@ -319,13 +325,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Register with Prefect Cloud"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "<hr>\n",
+    "\n",
+    "## Register with Prefect Cloud\n",
+    "\n",
     "Now that the business logic of the flow is complete, we can add information that Saturn will need to know to run it."
    ]
   },
@@ -335,20 +338,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "integration = PrefectCloudIntegration(prefect_cloud_project_name=PREFECT_CLOUD_PROJECT_NAME)\n",
-    "flow = integration.register_flow_with_saturn(flow)"
+    "integration = PrefectCloudIntegration(prefect_cloud_project_name=PREFECT_CLOUD_PROJECT_NAME)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Next, run `register_flow_with_saturn().\n",
+    "\n",
     "`register_flow_with_saturn()` does a few important things:\n",
     "    \n",
-    "* specifies how and where the flow's code is stored so it can be retrieved by a Prefect Cloud agent\n",
-    "    - see `flow.storage`\n",
-    "* specifies the infrastructure needed to run the flow. In this case, it uses a `KubernetesJobEnvironment` with a Saturn `Dask` cluster`\n",
-    "    - see `flow.environment`"
+    "* specifies how and where the flow's code is stored so it can be retrieved by a Prefect Cloud agent (see `flow.storage`)\n",
+    "* specifies the infrastructure needed to run the flow. In this case, it uses a `KubernetesJobEnvironment` with a Saturn Dask cluster (see `flow.environment`)\n",
+    "    \n",
+    "The code below also customizes the Dask cluster used when executing the flow.\n",
+    "\n",
+    "* `n_workers = 3`: use 3 workers\n",
+    "* `worker_size =\"xlarge\"`: each worker has 2 CPU cores and 16 GB RAM\n",
+    "    - **NOTE**: you can find the full list of sizes with `prefect_saturn.describe_sizes()`\n",
+    "* `autoclose = False`: leave the Dask cluster running after the flow run finishes\n",
+    "* `worker_is_spot = False`: don't use spot instances for workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow = integration.register_flow_with_saturn(\n",
+    "    flow=flow,\n",
+    "    dask_cluster_kwargs={\n",
+    "        \"n_workers\": 3,\n",
+    "        \"worker_size\": \"xlarge\",\n",
+    "        \"autoclose\": False,\n",
+    "        \"worker_is_spot\": False,\n",
+    "    },\n",
+    ")"
    ]
   },
   {
@@ -371,7 +398,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run the flow\n",
+    "<hr>\n",
+    "\n",
+    "## Run the flow\n",
     "\n",
     "You shouldn't have to do anything to run the flow. Now that Prefect Cloud has it, it will be run once every 10 minutes. You can confirm this by doing all of the following:\n",
     "\n",

--- a/examples/examples-cpu/prefect/prefect-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-scoring.ipynb
@@ -32,7 +32,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Environment Setup\n",
+    "<hr>\n",
+    "\n",
+    "## Environment Setup\n",
     "\n",
     "The code in this notebook uses `prefect` for orchestration *(figuring out what to do, and in what order)* and `dask` for execution *(doing the things)*.\n",
     "\n",
@@ -75,7 +77,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define Tasks\n",
+    "<hr>\n",
+    "\n",
+    "## Define Tasks\n",
     "\n",
     "`prefect` refers to a workload as a \"flow\", which comprises multiple individual things to do called \"tasks\". From [the Prefect docs](https://docs.prefect.io/core/concepts/tasks.html):\n",
     "\n",
@@ -210,7 +214,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Construct a Flow\n",
+    "<hr>\n",
+    "\n",
+    "## Construct a Flow\n",
     "\n",
     "Now that all of the task logic has been defined, the next step is to compose those tasks into a \"flow\". From [the Prefect docs](https://docs.prefect.io/core/concepts/flows.html):\n",
     "\n",
@@ -271,6 +277,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Run the flow with Dask\n",
     "\n",
     "If you run `flow.visualize()` on the code above, you'll see that this flow is not linear. Some tasks are independent of others, and can be run at the same time."


### PR DESCRIPTION
This PR updates the Prefect Cloud example to show how you can use `prefect-saturn` + `dask-saturn` to programmatically change the Dask cluster used to run your prefect flows.

It also adds some small changes to section headers, for consistency with the other recent changes to the notebooks in this project (like #63 and #58 ).