### PR TITLE
split up snowflake connection and data loading

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/README.md
+++ b/examples/examples-cpu/nyc-taxi-snowflake/README.md
@@ -45,9 +45,7 @@ Create a credential for each of these variables:
 
 These variables will be used to [specify arguments](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) passed to `snowflake.connector.connect`.
 
-
 You will need to restart the Jupyter server if you add a Credential while it's running. The examples also utilize the environment variables SNOWFLAKE_WAREHOUSE, TAXI_DATABASE, and TAXI_SCHEMA for configuring the snowflake connection, but since these are not sensitive they can be set directly on the Jupyter server instead of setting them as Credentials. The Jupyter server will need to be stopped in order to edit its environment variables.
-
 
 To load the data, open up a Worksheet inside of Snowflake and run the commands in the [`load-data.sql`](load-data.sql) file.
 
@@ -179,7 +177,6 @@ curl -X POST \
     http://${DEPLOYMENT_URL}:8000/api/predict \
     -d '{"passenger_count": 1, "pickup_datetime": "2019-01-01T11:15:38Z", "pickup_taxizone_id": 37, "dropoff_taxizone_id": 215}'
 ```
-
 
 ### Hook up to dashboard
 

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -96,9 +96,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "<hr>\n",
     "\n",
-    "Load a sample from a single month for this exercise. Note we are loading the data with Dask now by defining a `dask.delayed` function to load partitions in parallel."
+    "## Connect to Snowflake\n",
+    "\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
+    "\n",
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -108,8 +121,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import dask.dataframe as dd\n",
-    "\n",
     "import snowflake.connector\n",
     "\n",
     "SNOWFLAKE_ACCOUNT = os.environ[\"SNOWFLAKE_ACCOUNT\"]\n",
@@ -129,6 +140,19 @@
     "    \"schema\": TAXI_SCHEMA,\n",
     "}\n",
     "conn = snowflake.connector.connect(**conn_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small resources. So let's just load a single month of taxi data for training.\n",
+    "\n",
+    "This example uses Snowflake to handle the hard work of creating new features, then creates a Dask DataFrame with the result. It uses `dask.delayed()` to load partitions of the query result in parallel on the worker, so that you don't have to load the entire query result in this Jupyter and then send it to the Dask cluster."
    ]
   },
   {
@@ -214,6 +238,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import dask.dataframe as dd\n",
+    "\n",
     "taxi = dd.from_delayed([load(conn_info, query, day) for day in dates])\n",
     "taxi = taxi.persist()\n",
     "_ = wait(taxi)"

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -53,9 +53,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "<hr>\n",
     "\n",
-    "Load a sample from a single month for this exercise"
+    "## Connect to Snowflake\n",
+    "\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
+    "\n",
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -87,6 +100,19 @@
     "}\n",
     "\n",
     "conn = snowflake.connector.connect(**conn_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small resources. So let's just load a single month of taxi data for training.\n",
+    "\n",
+    "This example uses Snowflake to handle the hard work of creating new features, then creates a `pandas` data frame with the result."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -104,9 +104,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "<hr>\n",
     "\n",
-    "Load a sample from a single month for this exercise. Note we are loading the data with Dask now by defining a `dask.delayed` function to load partitions in parallel."
+    "## Connect to Snowflake\n",
+    "\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
+    "\n",
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -136,6 +149,19 @@
     "    \"schema\": TAXI_SCHEMA,\n",
     "}\n",
     "conn = snowflake.connector.connect(**conn_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small resources. So let's just load a single month of taxi data for training.\n",
+    "\n",
+    "This example uses Snowflake to handle the hard work of creating new features, then creates a Dask DataFrame with the result. It uses `dask.delayed()` to load partitions of the query result in parallel on the worker, so that you don't have to load the entire query result in this Jupyter and then send it to the Dask cluster."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -51,9 +51,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "<hr>\n",
     "\n",
-    "Load a sample from a single month for this exercise"
+    "## Connect to Snowflake\n",
+    "\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
+    "\n",
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -82,6 +95,19 @@
     "    \"schema\": TAXI_SCHEMA,\n",
     "}\n",
     "conn = snowflake.connector.connect(**conn_info)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small resources. So let's just load a single month of taxi data for training.\n",
+    "\n",
+    "This example uses Snowflake to handle the hard work of creating new features, then creates a `pandas` data frame with the result."
    ]
   },
   {

--- a/examples/examples-cpu/snowflake/README.md
+++ b/examples/examples-cpu/snowflake/README.md
@@ -1,7 +1,6 @@
 |<img src="../_img/snowflake.png" width="400" /> |$~~~~~~~~~~~~~~~~~~$| <img src="../_img/saturn.png" width="400" />|
 | -- | -- | -- |
 
-
 # Using Snowflake with Saturn Cloud
 
 [Snowflake](https://www.snowflake.com/) is a data platform built for the cloud that allows for fast SQL queries. This example shows how to query data in Snowflake and pull into [Saturn Cloud](https://www.saturncloud.io/) for data science work. We will rely on the [Snowflake Connector for Python](https://docs.snowflake.com/en/user-guide/python-connector.html) to connect and issue queries from Python code.
@@ -40,15 +39,15 @@ conn = snowflake.connector.connect(
 
 # Load data into Snowflake
 
-This example utilizes [public NYC Taxi data](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). To prepare Snowflake and load some taxi data into a table, run the commands in the [`load-data.sql`](load-data.sql) script from a Snowflake worksheet.
+This example utilizes [public NYC Taxi data](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). To prepare Snowflake and load some taxi data into a table, run the commands in the [`load-data.sql`](./load-data.sql) script from a Snowflake worksheet.
 
 # Query data with Pandas
 
 If your table or query result fits into the memory of your Jupyter client, you can load data into a pandas dataframe using methods `fetch_pandas_all()` or `fetch_pandas_batch()` available in the Snowflake Connector for Python a.k.a. the Python Connector.
 
-See [`snowflake-pandas.ipynb`](snowflake-pandas.ipynb).
+See [`snowflake-pandas.ipynb`](./snowflake-pandas.ipynb).
 
 # Query data with Dask
 If your table or query result _don't_ fit into the memory of the computer running your Jupyter client, you can use Dask! Then you can take advantage of using a Dask cluster with Saturn to speed up your computations.
 
-See [`snowflake-dask.ipynb`](snowflake-dask.ipynb).
+See [`snowflake-dask.ipynb`](./snowflake-dask.ipynb).

--- a/examples/examples-cpu/snowflake/snowflake-dask.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-dask.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Snowflake + Dask\n",
     "\n",
-    "How to load data from a Snowflake table or query into a Dask dataframe\n",
-    "\n",
     "<table>\n",
     "    <tr>\n",
     "        <td>\n",
@@ -24,11 +22,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This tutorial describes how to connect to Snowflake, load data into a Snowflake table, and work with that data in Dask."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
     "## Connect to Snowflake\n",
     "\n",
-    "See [README](README.md) for more details on how to set up the credentials environment variables for SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, and SNOWFLAKE_PASSWORD.\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
     "\n",
-    "The other variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running `load-data.sql`. Note that in order to update environment variables your Jupyter server will need to be stopped."
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -71,6 +87,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Set up a query template\n",
     "\n",
     "We need to set up a query template containing a bind variable that will result in Dask issuing multiple queries that each extract a slice of the taxi data based on the pickup_datetime column. These slices will become our partitions in a Dask dataframe. We use a [binding for the Snowflake query](https://docs.snowflake.com/en/user-guide/python-connector-example.html#binding-data) so that we can pass different date values at execution time."
@@ -112,7 +130,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Initialize Dask cluster"
+    "<hr>\n",
+    "\n",
+    "## Initialize Dask cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to work with large datasets using Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores, 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -137,9 +193,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you initialized your cluster from right here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready\n",
+    "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    "> **Pro tip:** Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {
@@ -155,6 +211,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Load larger data with Dask!\n",
     "\n",
     "We set up a function with `dask.delayed`. `@delayed` is a decorator that turns a Python function into a function suitable for running on the Dask cluster. When you execute a delayed function, instead of executing the operation, it returns a delayed result that represents what the return value of the function will be. `dask.dataframe.from_delayed` takes a list of these delayed objects, and concatenates them into a Dask dataframe."

--- a/examples/examples-cpu/snowflake/snowflake-pandas.ipynb
+++ b/examples/examples-cpu/snowflake/snowflake-pandas.ipynb
@@ -6,8 +6,6 @@
    "source": [
     "# Snowflake + Pandas\n",
     "\n",
-    "How to load data from a Snowflake table or query into a pandas dataframe\n",
-    "\n",
     "<table>\n",
     "    <tr>\n",
     "        <td>\n",
@@ -21,11 +19,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This tutorial describes how to connect to Snowflake, load data into a Snowflake table, and work with that data in `pandas`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
     "## Connect to Snowflake\n",
     "\n",
-    "See [README](README.md) for more details on how to set up the credentials environment variables for SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, and SNOWFLAKE_PASSWORD.\n",
+    "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
     "\n",
-    "The other variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running `load-data.sql`. Note that in order to update environment variables your Jupyter server will need to be stopped."
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when running [`load-data.sql`](./load-data.sql). Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {
@@ -68,6 +84,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Run query\n",
     "\n",
     "The [Snowflake Connector for Python](https://docs.snowflake.com/en/user-guide/python-connector-pandas.html) has `fetch_pandas_all()` and `fetch_pandas_batches()` methods that utilize [Arrow](https://arrow.apache.org/) for fast data exchange."

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids-dask.ipynb
@@ -182,7 +182,16 @@
     "\n",
     "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
     "\n",
-    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs."
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when loading data into Snowflake. Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-rapids.ipynb
@@ -106,7 +106,16 @@
     "\n",
     "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
     "\n",
-    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs."
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when loading data into Snowflake. Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -91,7 +91,16 @@
     "\n",
     "This examples uses data stored in a Snowflake data warehouse. The code below expects the following environment variables to be set. If you haven't set these, return to the Saturn project page to set them.\n",
     "\n",
-    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs."
+    "* `SNOWFLAKE_ACCOUNT`\n",
+    "* `SNOWFLAKE_USER`\n",
+    "* `SNOWFLAKE_PASSWORD`\n",
+    "* `SNOWFLAKE_WAREHOUSE`\n",
+    "* `TAXI_DATABASE`\n",
+    "* `TAXI_SCHEMA`\n",
+    "\n",
+    "For more details on these environment variables, see [\"Connecting to Snowflake\"](https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-to-snowflake) in the `snowflake-connector-python` docs.\n",
+    "\n",
+    "The `SNOWFLAKE_*` variables should be set up as Saturn credentials. The `TAXI_*` variables can be set on your Jupyter server or overwritten below based on the Snowflake warehouse and schema you used when loading data into Snowflake. Note that in order to update environment variables your Jupyter server will need to be stopped."
    ]
   },
   {


### PR DESCRIPTION
Today, the snowflake example notebooks have a section called "Load data and feature engineering". This PR proposes breaking that up into "Connect to Snowflake" and "Load Data". I think that connecting to snowflake is complicated enough that it deserves to be its own section.

This also adds a bit more information to the "Connect to Snowflake" section. We currently ask people to consult the README, but in my current effort I'm trying to make the notebooks more self-contained so that people don't get discouraged or confused as they work through them. This means more duplication but I think it's worth it.