### PR TITLE
improve dask-saturn descriptions in examples-cpu notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -48,7 +48,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initialize Dask Cluster"
+    "<hr>\n",
+    "\n",
+    "## Initialize A Dask Cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to apply more computing resources to machine learning training. This is done with Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores and 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -66,7 +104,6 @@
     "    n_workers=n_workers,\n",
     "    scheduler_size=\"medium\",\n",
     "    worker_size=\"large\",\n",
-    "    nthreads=2,\n",
     ")\n",
     "client = Client(cluster)\n",
     "cluster"
@@ -76,11 +113,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open the dashboard (link above ^) and watch it when you execute some commands, you'll see which tasks are running across the cluster.\n",
-    "\n",
     "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -54,9 +54,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initialize Dask cluster\n",
+    "<hr>\n",
     "\n",
-    "The code below uses [`dask-saturn`](https://github.com/saturncloud/dask-saturn) to create a Dask cluster or connect to one that is already running."
+    "## Initialize A Dask Cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to apply more computing resources to machine learning training. This is done with Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores and 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -74,7 +110,6 @@
     "    n_workers=n_workers,\n",
     "    scheduler_size=\"medium\",\n",
     "    worker_size=\"large\",\n",
-    "    nthreads=2,\n",
     ")\n",
     "client = Client(cluster)\n",
     "cluster"
@@ -84,11 +119,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open the dashboard (link above ^) and watch it when you execute some commands, you'll see which tasks are running across the cluster.\n",
-    "\n",
     "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
+++ b/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
@@ -42,9 +42,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Launch Dask cluster\n",
+    "<hr>\n",
     "\n",
-    "We will need to do some data processing that exceeds the capacity of our JupyterLab client. To monitor the status of your cluster, visit the \"Logs\" page. "
+    "## Initialize A Dask Cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to apply more computing resources to machine learning training. This is done with Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores and 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -57,9 +93,7 @@
     "from dask_saturn import SaturnCluster\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(\n",
-    "    n_workers=n_workers, scheduler_size=\"medium\", worker_size=\"large\", nthreads=2\n",
-    ")\n",
+    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size=\"medium\", worker_size=\"large\")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -68,9 +102,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you initialized your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
+    "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -37,7 +37,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initialize Dask Cluster"
+    "<hr>\n",
+    "\n",
+    "## Initialize A Dask Cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to apply more computing resources to machine learning training. This is done with Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores and 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -54,7 +92,6 @@
     "    n_workers=n_workers,\n",
     "    scheduler_size=\"medium\",\n",
     "    worker_size=\"large\",\n",
-    "    nthreads=2,\n",
     ")\n",
     "client = Client(cluster)\n",
     "cluster"
@@ -64,11 +101,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open the dashboard (link above ^) and watch it when you execute some commands, you'll see which tasks are running across the cluster.\n",
-    "\n",
     "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -51,9 +51,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initialize Dask cluster\n",
+    "<hr>\n",
     "\n",
-    "The code below uses [`dask-saturn`](https://github.com/saturncloud/dask-saturn) to create a Dask cluster or connect to one that is already running."
+    "## Initialize A Dask Cluster\n",
+    "\n",
+    "This tutorial uses multiple machines to show how to apply more computing resources to machine learning training. This is done with Dask. Saturn Cloud offers managed Dask clusters, which can be provisioned and modified programmatically.\n",
+    "\n",
+    "The code below creates a Dask cluster using [`dask-saturn`](https://github.com/saturncloud/dask-saturn), the official Dask client for Saturn Cloud. It creates a cluster with the following specs:\n",
+    "\n",
+    "* `n_workers=3` --> 3 machines in the cluster\n",
+    "* `scheduler_size='medium'` --> the Dask scheduler will have 4GB of RAM and 2 CPU cores\n",
+    "* `worker_size='large'` --> each worker machine will have 2 CPU cores and 16GB of RAM\n",
+    "\n",
+    "To see a list of possible sizes, run the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask_saturn\n",
+    "\n",
+    "dask_saturn.describe_sizes()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `dask-saturn` code below creates two important objects: a cluster and a client.\n",
+    "\n",
+    "* `cluster`: knows about and manages the scheduler and workers\n",
+    "    - can be used to create, resize, reconfigure, or destroy those resources\n",
+    "    - knows how to communicate with the scheduler, and where to find logs and diagnostic dashboards\n",
+    "* `client`: tells the cluster to do things\n",
+    "    - can send work to the cluster\n",
+    "    - can restart all the worker processes\n",
+    "    - can send data to the cluster or pull data back from the cluster"
    ]
   },
   {
@@ -66,9 +102,7 @@
     "from dask_saturn import SaturnCluster\n",
     "\n",
     "n_workers = 3\n",
-    "cluster = SaturnCluster(\n",
-    "    n_workers=n_workers, scheduler_size=\"medium\", worker_size=\"large\", nthreads=2\n",
-    ")\n",
+    "cluster = SaturnCluster(n_workers=n_workers, scheduler_size=\"medium\", worker_size=\"large\")\n",
     "client = Client(cluster)\n",
     "cluster"
    ]
@@ -77,11 +111,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Open the dashboard (link above ^) and watch it when you execute some commands, you'll see which tasks are running across the cluster.\n",
-    "\n",
     "If you created your cluster here in this notebook, it might take a few minutes for all your nodes to become available. You can run the chunk below to block until all nodes are ready.\n",
     "\n",
-    ">**Pro tip**: Create and/or start your cluster from the \"Dask\" page in Saturn if you want to get a head start!"
+    ">**Pro tip**: Create and/or start your cluster in the Saturn UI if you want to get a head start!"
    ]
   },
   {


### PR DESCRIPTION
Many of the examples in `examples-cpu` have a section called "Initialize a Dask Cluster" followed by a minimal description and some code. This PR adds more explanatory text (the same text that was added to GPU notebooks in #58 and #64), so that people can hopefully get a deeper understanding of how to work with Dask in Saturn.