### PR TITLE
add description to every notebook

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/dashboard.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/dashboard.ipynb
@@ -6,6 +6,7 @@
    "source": [
     "# Running dashboard \n",
     "\n",
+    "This notebook describes how to create a dashboard in Saturn, based on code you've written in a Jupyter notebook.\n",
     "\n",
     "### From notebook\n",
     "\n",

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hyperparameter tuning\n",
-    "\n",
-    "## Dask cluster\n",
+    "# Hyperparameter tuning (multi-node with Dask)\n",
     "\n",
     "<table>\n",
     "    <tr>\n",
@@ -18,6 +16,17 @@
     "        </td>\n",
     "    </tr>\n",
     "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [`dask-ml`](https://ml.dask.org/) to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [`dask-ml`](https://ml.dask.org/) to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?"
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -4,9 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hyperparameter tuning\n",
-    "\n",
-    "## Single-node scikit-learn\n",
+    "# Hyperparameter tuning (single-node)\n",
     "\n",
     "<table>\n",
     "    <tr>\n",
@@ -18,6 +16,19 @@
     "        </td>\n",
     "    </tr>\n",
     "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data from Snowflake into a `pandas` data frame and use `scikit-learn` to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this dask-ml notebook](./hyperparameter-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "In this exercise, you'll load data from Snowflake into a `pandas` data frame and use `scikit-learn` to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this dask-ml notebook](./hyperparameter-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "In this exercise, you'll load data from Snowflake into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "This notebook gives an introductory tutorial on how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
    ]

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -25,7 +25,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook describes how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data from Snowflake into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "This notebook gives an introductory tutorial on how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "In this exercise, you'll load data from Snowflake into a `pandas` data frame and use XGBoost to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -19,6 +19,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data from Snowflake into a `pandas` data frame and use XGBoost to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -38,13 +51,6 @@
     "]\n",
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"tip_fraction\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/dashboard.ipynb
+++ b/examples/examples-cpu/nyc-taxi/dashboard.ipynb
@@ -6,6 +6,7 @@
    "source": [
     "# Running dashboard \n",
     "\n",
+    "This notebook describes how to create a dashboard in Saturn, based on code you've written in a Jupyter notebook.\n",
     "\n",
     "### From notebook\n",
     "\n",

--- a/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
+++ b/examples/examples-cpu/nyc-taxi/data-aggregation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Data Aggregation for Dashboard\n",
     "\n",
-    "This notebook contains the data aggregation code to prepare data files for the dashboard. You can run this notebook to see how Dask is used with a Saturn cluster for data processing, but the files generated here will not be used by any of the examples. The dashboard uses pre-aggregated files from Saturn's public S3 bucket."
+    "This notebook contains the data aggregation code to prepare data files for [the dashboard](./dashboard.ipynb). You can run this notebook to see how Dask is used with a Saturn cluster for data processing, but the files generated here will not be used by any of the examples. The dashboard uses pre-aggregated files from Saturn's public S3 bucket."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -4,11 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hyperparameter tuning\n",
-    "\n",
-    "## Dask cluster\n",
+    "# Hyperparameter tuning (multi-node with Dask)\n",
     "\n",
     "<img src=\"../_img/dask-horizontal.svg\" width=\"400\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [`dask-ml`](https://ml.dask.org/) to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [`dask-ml`](https://ml.dask.org/) to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?"
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "In this exercise, you'll load data into a `pandas` data frame and use `scikit-learn` to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this dask-ml notebook](./hyperparameter-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
@@ -4,11 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hyperparameter tuning\n",
-    "\n",
-    "## Single-node scikit-learn\n",
+    "# Hyperparameter tuning (single-node)\n",
     "\n",
     "<img src=\"../_img/scikit-learn.png\" width=\"300\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data into a `pandas` data frame and use `scikit-learn` to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this dask-ml notebook](./hyperparameter-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]
   },
   {
@@ -31,13 +42,6 @@
     "]\n",
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"tip_fraction\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this dask-ml notebook](./hyperparameter-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "This notebook gives an introductory tutorial on how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
    ]

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -22,7 +22,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook describes how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data into a [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) and use [XGBoost](https://xgboost.readthedocs.io/en/latest/index.html) to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "This notebook gives an introductory tutorial on how to use Dask to scale training of XGBoost models. For more detailed information, see [\"Distributed XGBoost with Dask\"](https://xgboost.readthedocs.io/en/latest/tutorials/dask.html) in the XGBoost documentation and [\"XGBoost Training with Dask\"](https://www.saturncloud.io/docs/tutorials/xgboost/) in Saturn Cloud's documentation."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -10,6 +10,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook describes a machine learning training workflow using the famous [NYC Taxi Dataset](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page). That dataset contains information on taxi trips in New York City.\n",
+    "\n",
+    "In this exercise, you'll load data into a `pandas` data frame and use XGBoost to answer this question\n",
+    "\n",
+    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "\n",
+    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -29,13 +42,6 @@
     "]\n",
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"tip_fraction\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "In this exercise, you'll load data into a `pandas` data frame and use XGBoost to answer this question\n",
     "\n",
-    "> based on characteristics that can be known at the beginning of a trip, will this trip result in a high tip?\n",
+    "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
     "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
    ]


### PR DESCRIPTION
Today, some of the example notebooks here have a title and some logos, then go straight into code. This PR proposes adding short descriptions to the beginning of each one, setting up the context for the notebook. I think this will make the notebooks easier to follow and help people to evaluate right at the beginning whether or not the notebook they've opened is one they want to work through.