### PR TITLE
add more explanatory text in XGBoost notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -26,28 +26,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "numeric_feat = [\n",
-    "    \"pickup_weekday\",\n",
-    "    \"pickup_weekofyear\",\n",
-    "    \"pickup_hour\",\n",
-    "    \"pickup_week_hour\",\n",
-    "    \"pickup_minute\",\n",
-    "    \"passenger_count\",\n",
-    "]\n",
-    "categorical_feat = [\n",
-    "    \"PULocationID\",\n",
-    "    \"DOLocationID\",\n",
-    "]\n",
-    "features = numeric_feat + categorical_feat\n",
-    "y_col = \"tip_fraction\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -103,8 +81,7 @@
     "\n",
     "n_workers = 3\n",
     "cluster = SaturnCluster(n_workers=n_workers, scheduler_size=\"medium\", worker_size=\"large\")\n",
-    "client = Client(cluster)\n",
-    "cluster"
+    "client = Client(cluster)"
    ]
   },
   {
@@ -129,9 +106,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "### Monitor Resource Usage\n",
     "\n",
-    "Load a sample from a single month for this exercise"
+    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "\n",
+    "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Click that dashboard link to view some diagnostic information about the Dask cluster. This can be used to view the current resource utilization of workers in the cluster and lots of information about what they're currently working on."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small, relatively inexpensive resources. So let's just load a single month of taxi data for training."
    ]
   },
   {
@@ -151,6 +157,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code below computes the size of this dataset in memory."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -160,29 +173,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def prep_df(df: dd.DataFrame) -> dd.DataFrame:\n",
-    "    \"\"\"\n",
-    "    Generate features from a raw taxi dataframe.\n",
-    "    \"\"\"\n",
-    "    df = df[df.fare_amount > 0]  # avoid divide-by-zero\n",
-    "    df[\"tip_fraction\"] = df.tip_amount / df.fare_amount\n",
+    "You can examine the structure of the data with Dask DataFrame commands:\n",
     "\n",
-    "    df[\"pickup_weekday\"] = df.tpep_pickup_datetime.dt.weekday\n",
-    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.isocalendar().week\n",
-    "    df[\"pickup_hour\"] = df.tpep_pickup_datetime.dt.hour\n",
-    "    df[\"pickup_week_hour\"] = (df.pickup_weekday * 24) + df.pickup_hour\n",
-    "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",
-    "    df = df[features + [y_col]].astype(float).fillna(-1)\n",
-    "\n",
-    "    return df\n",
-    "\n",
-    "\n",
-    "taxi_train = prep_df(taxi)"
+    "`.head()` = view the first few rows"
    ]
   },
   {
@@ -191,14 +187,119 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_train.head()"
+    "taxi.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dask performs computations in a [lazy manner](https://tutorial.dask.org/01x_lazy.html), so we persist the dataframe to perform data loading and feature processing once."
+    "`.dtypes` = list all the columns and the type of data in them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Prep for Training\n",
+    "\n",
+    "Before training a model, we need to transform this dataset into a format that's better-suited to the research question. The function below does that with Dask DataFrame operations.\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Compute the Target**\n",
+    "\n",
+    "The raw data don't contain a column that cleanly describes whether or not a particular ride could be considered a \"high\" tip. So we need to add one! In this exercise, a \"high\" tip is one that is greater than 20% of the fare amount.\n",
+    "\n",
+    "**Add Features**\n",
+    "\n",
+    "Giving a machine learning model a richer description of each training observation improves its ability to describe the relationship between those observations' characteristics and the target. These characteristics are called \"features\".\n",
+    "\n",
+    "For example, instead of giving a model a raw timestamp, it can be valuable to provide multiple derived characteristics like hour of the day and day of the week. It's plausible, for example, that weekend rides might have a different distribution of tips because they tend to be for leisure, where weekday rides might be mostly people travelling for work.\n",
+    "\n",
+    "**Remove Unused Features**\n",
+    "\n",
+    "If the goal is to produce a model that could predict whether or not a tip will be high *at the beginning of the trip*, then characteristics that can only be known AFTER the tip have to be excluded. For example, you can't know the dropoff time or the type of payment until a ride has concluded.\n",
+    "\n",
+    "Such features should be dropped before training.\n",
+    "    \n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prep_df(df: dd.DataFrame, target_col: str) -> dd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Prepare a raw taxi dataframe for training.\n",
+    "        * computes the target ('high_tip')\n",
+    "        * adds features\n",
+    "        * removes unused features\n",
+    "    \"\"\"\n",
+    "    numeric_feat = [\n",
+    "        \"pickup_weekday\",\n",
+    "        \"pickup_weekofyear\",\n",
+    "        \"pickup_hour\",\n",
+    "        \"pickup_week_hour\",\n",
+    "        \"pickup_minute\",\n",
+    "        \"passenger_count\",\n",
+    "    ]\n",
+    "    categorical_feat = [\n",
+    "        \"PULocationID\",\n",
+    "        \"DOLocationID\",\n",
+    "    ]\n",
+    "    features = numeric_feat + categorical_feat\n",
+    "    df = df[df.fare_amount > 0]  # avoid divide-by-zero\n",
+    "    df[target_col] = df.tip_amount / df.fare_amount\n",
+    "\n",
+    "    df[\"pickup_weekday\"] = df.tpep_pickup_datetime.dt.weekday\n",
+    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.isocalendar().week\n",
+    "    df[\"pickup_hour\"] = df.tpep_pickup_datetime.dt.hour\n",
+    "    df[\"pickup_week_hour\"] = (df.pickup_weekday * 24) + df.pickup_hour\n",
+    "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",
+    "    df = df[features + [target_col]].astype(float).fillna(-1)\n",
+    "\n",
+    "    return df\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the code below to get a new data frame, `taxi_train`, that can be used directly for model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_col = \"tip_fraction\"\n",
+    "taxi_train = prep_df(taxi, target_col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dask performs computations in a [lazy manner](https://tutorial.dask.org/01x_lazy.html), so we persist the dataframe to perform data loading and feature processing."
    ]
   },
   {
@@ -209,7 +310,58 @@
    "source": [
     "%%time\n",
     "taxi_train = taxi_train.persist()\n",
-    "_ = wait(taxi_train)"
+    "_ = wait(taxi_train)\n",
+    "\n",
+    "taxi_train.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`taxi_train` is a Dask DataFrame that will be passed in to a machine learning model. Since this is a binary classification task, before proceeding we should examine the distributions of 1s and 0s in the target. This can be done with by combining `.groupby()` and `.count()`\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Target Distribution**\n",
+    "    \n",
+    "In binary classification tasks, we ask machine learning models to learn the difference between records that produced a 0 for some target and those that produce a 1. In this example:\n",
+    "    \n",
+    "* `high_tip = 1`: \"this trip resulted in a high tip\"\n",
+    "* `high_tip = 0`: \"this trip did not result in a high tip\"\n",
+    "    \n",
+    "The \"distribution\" of this target just means \"what % of the trips ended in a high tip?\". This is important to understand because we might have to change our modelling approach if the distribution was uneven. For example, if 99% of trips did NOT end in a high tip, a model that just always guessed \"not a high tip\" would achieve an accuracy of 99%.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_train.groupby(\"high_tip\")[\"high_tip\"].count().compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before going further, check the first few rows of the dataset to make sure that the features look reasonable.\n",
+    "\n",
+    "Now that the dataframe has been processed, check its size in memory again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"Num rows: {len(taxi_train)}, Size: {taxi_train.memory_usage(deep=True).sum().compute() / 1e9} GB\"\n",
+    ")"
    ]
   },
   {
@@ -243,6 +395,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "features = [c for c in taxi_train.columns if c != target_col]\n",
+    "\n",
     "data = taxi_train[features]\n",
     "label = taxi_train[y_col]\n",
     "\n",
@@ -280,6 +434,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
+    "## Save model\n",
+    "\n",
     "`xgb.dask.train()` produces a regular `xgb.core.Booster` object, the same model object produced by non-Dask training."
    ]
   },
@@ -299,7 +457,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save model"
+    "Once you've trained a model, save it in a file to use later for scoring or for comparison with other models.\n",
+    "\n",
+    "There are several ways to do this, but `cloudpickle` is likely to give you the best experience. It handles some common drawbacks of the built-in `pickle` library.\n",
+    "\n",
+    "`cloudpickle` can be used to write a Python object to bytes, and to create a Python object from that binary representation."
    ]
   },
   {
@@ -323,6 +485,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Calculate metrics on test set\n",
     "\n",
     "Use a different month for test set"

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -273,9 +273,7 @@
     "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",
     "    df = df[features + [target_col]].astype(float).fillna(-1)\n",
     "\n",
-    "    return df\n",
-    "\n",
-    "\n"
+    "    return df"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -396,7 +396,7 @@
     "features = [c for c in taxi_train.columns if c != target_col]\n",
     "\n",
     "data = taxi_train[features]\n",
-    "label = taxi_train[y_col]\n",
+    "label = taxi_train[target_col]\n",
     "\n",
     "dtrain = xgb.dask.DaskDMatrix(client=client, data=data, label=label)"
    ]
@@ -539,7 +539,7 @@
    "source": [
     "from dask_ml.metrics import mean_squared_error\n",
     "\n",
-    "mean_squared_error(taxi_test[y_col].to_dask_array(), preds.to_dask_array(), squared=False)"
+    "mean_squared_error(taxi_test[target_col].to_dask_array(), preds.to_dask_array(), squared=False)"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -10,28 +10,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "numeric_feat = [\n",
-    "    \"pickup_weekday\",\n",
-    "    \"pickup_weekofyear\",\n",
-    "    \"pickup_hour\",\n",
-    "    \"pickup_week_hour\",\n",
-    "    \"pickup_minute\",\n",
-    "    \"passenger_count\",\n",
-    "]\n",
-    "categorical_feat = [\n",
-    "    \"PULocationID\",\n",
-    "    \"DOLocationID\",\n",
-    "]\n",
-    "features = numeric_feat + categorical_feat\n",
-    "y_col = \"tip_fraction\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -42,9 +20,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Load data and feature engineering\n",
+    "<hr>\n",
     "\n",
-    "Load a sample from a single month for this exercise"
+    "## Load data\n",
+    "\n",
+    "This example is designed to run quickly with small, relatively inexpensive resources. So let's just load a single month of taxi data for training."
    ]
   },
   {
@@ -62,12 +42,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "print(f\"Num rows: {len(taxi)}, Size: {taxi.memory_usage(deep=True).sum() / 1e6} MB\")"
+    "The code below computes the size of this dataset in memory. One month is about 7.6 million rows and 1.5 GB."
    ]
   },
   {
@@ -76,43 +54,236 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def prep_df(df: pd.DataFrame) -> pd.DataFrame:\n",
-    "    \"\"\"\n",
-    "    Generate features from a raw taxi dataframe.\n",
-    "    \"\"\"\n",
-    "    df = df.copy()\n",
-    "    df = df[df.fare_amount > 0]  # avoid divide-by-zero\n",
-    "    df[\"tip_fraction\"] = df.tip_amount / df.fare_amount\n",
-    "\n",
-    "    df[\"pickup_weekday\"] = df.tpep_pickup_datetime.dt.weekday\n",
-    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.isocalendar().week\n",
-    "    df[\"pickup_hour\"] = df.tpep_pickup_datetime.dt.hour\n",
-    "    df[\"pickup_week_hour\"] = (df.pickup_weekday * 24) + df.pickup_hour\n",
-    "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",
-    "    df = df[features + [y_col]].astype(float).fillna(-1)\n",
-    "\n",
-    "    return df\n",
-    "\n",
-    "\n",
-    "taxi_train = prep_df(taxi)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "taxi_train.head()"
+    "print(f\"Num rows: {len(taxi)}, Size: {round(taxi.memory_usage(deep=True).sum() / 1e9, 2)} GB\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Train a model\n",
+    "You can examine the structure of the data with `pandas` commands:\n",
     "\n",
-    "Setting `n_jobs = multiprocessing.cpu_count()` tells xgboost it can use all available cores on this machine to complete training."
+    "`.head()` = view the first few rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "`.dtypes` = list all the columns and the type of data in them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Prep for Training\n",
+    "\n",
+    "Before training a model, we need to transform this dataset into a format that's better-suited to the research question. The function below does that with `pandas` operations.\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Compute the Target**\n",
+    "\n",
+    "The raw data don't contain a column that cleanly describes whether or not a particular ride could be considered a \"high\" tip. So we need to add one! In this exercise, a \"high\" tip is one that is greater than 20% of the fare amount.\n",
+    "\n",
+    "**Add Features**\n",
+    "\n",
+    "Giving a machine learning model a richer description of each training observation improves its ability to describe the relationship between those observations' characteristics and the target. These characteristics are called \"features\".\n",
+    "\n",
+    "For example, instead of giving a model a raw timestamp, it can be valuable to provide multiple derived characteristics like hour of the day and day of the week. It's plausible, for example, that weekend rides might have a different distribution of tips because they tend to be for leisure, where weekday rides might be mostly people travelling for work.\n",
+    "\n",
+    "**Remove Unused Features**\n",
+    "\n",
+    "If the goal is to produce a model that could predict whether or not a tip will be high *at the beginning of the trip*, then characteristics that can only be known AFTER the tip have to be excluded. For example, you can't know the dropoff time or the type of payment until a ride has concluded.\n",
+    "\n",
+    "Such features should be dropped before training.\n",
+    "    \n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prep_df(df: pd.DataFrame, target_col: str) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Prepare a raw taxi dataframe for training.\n",
+    "        * computes the target ('high_tip')\n",
+    "        * adds features\n",
+    "        * removes unused features\n",
+    "    \"\"\"\n",
+    "    numeric_feat = [\n",
+    "        \"pickup_weekday\",\n",
+    "        \"pickup_weekofyear\",\n",
+    "        \"pickup_hour\",\n",
+    "        \"pickup_week_hour\",\n",
+    "        \"pickup_minute\",\n",
+    "        \"passenger_count\",\n",
+    "    ]\n",
+    "    categorical_feat = [\n",
+    "        \"PULocationID\",\n",
+    "        \"DOLocationID\",\n",
+    "    ]\n",
+    "    features = numeric_feat + categorical_feat\n",
+    "    df = df.copy()\n",
+    "    df = df[df.fare_amount > 0]  # avoid divide-by-zero\n",
+    "    df[target_col] = df.tip_amount / df.fare_amount\n",
+    "\n",
+    "    df[\"pickup_weekday\"] = df.tpep_pickup_datetime.dt.weekday\n",
+    "    df[\"pickup_weekofyear\"] = df.tpep_pickup_datetime.dt.isocalendar().week\n",
+    "    df[\"pickup_hour\"] = df.tpep_pickup_datetime.dt.hour\n",
+    "    df[\"pickup_week_hour\"] = (df.pickup_weekday * 24) + df.pickup_hour\n",
+    "    df[\"pickup_minute\"] = df.tpep_pickup_datetime.dt.minute\n",
+    "    df = df[features + [target_col]].astype(float).fillna(-1)\n",
+    "\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the code below to get a new data frame, `taxi_train`, that can be used directly for model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_col = \"tip_fraction\"\n",
+    "taxi_train = prep_df(taxi, target_col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`taxi_train` is a `pandas` dataframe that will be passed in to a machine learning model. Since this is a binary classification task, before proceeding we should examine the distributions of 1s and 0s in the target. This can be done with the `.value_counts()` method.\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Target Distribution**\n",
+    "    \n",
+    "In binary classification tasks, we ask machine learning models to learn the difference between records that produced a 0 for some target and those that produce a 1. In this example:\n",
+    "    \n",
+    "* `high_tip = 1`: \"this trip resulted in a high tip\"\n",
+    "* `high_tip = 0`: \"this trip did not result in a high tip\"\n",
+    "    \n",
+    "The \"distribution\" of this target just means \"what % of the trips ended in a high tip?\". This is important to understand because we might have to change our modelling approach if the distribution was uneven. For example, if 99% of trips did NOT end in a high tip, a model that just always guessed \"not a high tip\" would achieve an accuracy of 99%.\n",
+    "\n",
+    "</details>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_train[target_col].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before going further, check the first few rows of the dataset to make sure that the features look reasonable.\n",
+    "\n",
+    "Now that the dataframe has been processed, check its size in memory again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    f\"Num rows: {len(taxi_train)}, Size: {round(taxi_train.memory_usage(deep=True).sum() / 1e9, 2)} GB\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see above, removing unused columns dropped the size of the training data to 0.55 GB, about one third the size of the raw data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>\n",
+    "\n",
+    "## Train a Model\n",
+    "\n",
+    "Now that the data have been prepped, it's time to build a model!\n",
+    "\n",
+    "For this task, we'll use the `XGBRegressor` from `xgboost`. If you've never used XGBoost or need a refresher, see [the XGBoost Python docs](https://xgboost.readthedocs.io/en/latest/python/index.html).\n",
+    "\n",
+    "The code below initializes an `XGBRegressor` with the following parameter values.\n",
+    "\n",
+    "* `objective = \"reg:squarederror\"`: solve a regression problem, and use mean squared error as the loss function\n",
+    "* `tree_method = \"hist\"`: use the \"histogram\" method of building trees. This method sacrifices a small amount of training accuracy for much faster training time.\n",
+    "* `learning_rate = 0.1`: controls how much each new tree contributes to the overall model. 0.1 is an arbitrary value.\n",
+    "* `max_depth = 5`: stop growing a tree once it contains a leaf node that is 5 levels below the root\n",
+    "* `n_estimators = 50`: create a model with at most 50 trees\n",
+    "* `n_jobs = multiprocessing.cpu_count()`: use all available cores on this machine to parallelize training\n",
+    "* `verbosity = 1`: print INFO-level logs and above\n",
+    "\n",
+    "All other parameters use the defaults from [`XGBRegressor`](https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor).\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Setting max_depth**\n",
+    "    \n",
+    "Tree-based models split the training data into smaller and smaller groups, to try to group together records with similar values of the target. A tree can be thought of as a collection of rules like `pickup_hour greater than 11` and `pickup_minute less than 31.0`. As you add more rules, those groups (called \"leaf nodes\") get smaller. In an extreme example, a model could create a tree with enough rules to place each record in the training data into its own group. That would probably take a lot of rules, and would be referred to as a \"deep\" tree.\n",
+    "    \n",
+    "Deep trees are problematic because their descriptions of the world are too specific to be useful on new data. Imagine training a classification model to predict whether or not visitors to a theme park will ride a particular rollercoaster. You could measure the time down to the millisecond that every guest's ticket is scanned at the entrance, and a model might learn a rule like *\"if the guest has been to the park before and if the guest is older than 40 and younger than 41, and if the guest is staying at Hotel A and if the guest enters the park after 1:00:17.456 and if the guest enters the park earlier than 1:00:17.995, they will ride the rollercoaster\"*. This is very very unlikely to ever match any future visitors, and if it does it's unlikely that this prediction will be very good unless you have some reason to believe that a visitor arriving at 1:00:18 instead of 1:00:17 really changes the probability that they'll ride that rollercoaster.\n",
+    "    \n",
+    "To prevent this situation (called \"overfitting\"), most tree-based machine learning algorithms accept parameters that control how deep the trees can get. `max_depth` is common, and says \"don't create a rule more complex than this\". In the example above, that rule has a depth of 7.\n",
+    "    \n",
+    "1. visiting the park\n",
+    "2. has been to the park before?\n",
+    "3. older than 40?\n",
+    "4. younger than 41?\n",
+    "5. staying at Hotel A?\n",
+    "6. entered the park after 1:00:17.456?\n",
+    "7. entered the park before 1:00:17.995?\n",
+    "    \n",
+    "Setting `max_depth = 5` would have prevented those weirdly-specific timing rules from ever being generated.\n",
+    "    \n",
+    "Choosing good values for this parameter is part art, part science, and is outside the scope of this tutorial.\n",
+    "    \n",
+    "</details>"
    ]
   },
   {
@@ -136,20 +307,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the regressor created, fit it to some data! The code below uses `%%time` to print out a timing, so you can see how long it takes to train. This can be used to compare single-node, CPU `xgboost` to methods explored in other notebooks, or to test how changing some parameters changes the runtime for training.\n",
+    "\n",
+    "**NOTE:** This will take a few minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for this model to train."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
-    "_ = xgb_reg.fit(taxi_train[features], y=taxi_train[y_col])"
+    "\n",
+    "features = [c for c in taxi_train.columns if c != target_col]\n",
+    "\n",
+    "_ = xgb_reg.fit(taxi_train[features], y=taxi_train[target_col])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save model"
+    "<hr>\n",
+    "\n",
+    "## Save model\n",
+    "\n",
+    "Once you've trained a model, save it in a file to use later for scoring or for comparison with other models.\n",
+    "\n",
+    "There are several ways to do this, but `cloudpickle` is likely to give you the best experience. It handles some common drawbacks of the built-in `pickle` library.\n",
+    "\n",
+    "`cloudpickle` can be used to write a Python object to bytes, and to create a Python object from that binary representation."
    ]
   },
   {
@@ -173,9 +364,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Calculate metrics on test set\n",
     "\n",
-    "Use a different month for test set"
+    "Machine learning training tries to create a model which can produce useful results on new data that it didn't see during training. To test how well we've accomplished that in this example, read in another month of taxi data."
    ]
   },
   {
@@ -190,6 +383,31 @@
     ").sample(frac=0.01, replace=False)\n",
     "\n",
     "taxi_test = prep_df(taxi_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before creating predictions on this new dataset, it has to be transformed in exactly the way that the original training data were prepared. Thankfully you've already wrapped that transformation logic in a function!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taxi_test = prep_df(taxi_test, target_col=target_col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`scikit-learn` comes with many functions for calculating metrics that describe how well a model's predictions match the actual values. For a complete list, see [\"Metrics and scoring\"](https://scikit-learn.org/stable/modules/model_evaluation.html) in the `sciki-learn` docs.\n",
+    "\n",
+    "This tutorial uses the `roc_auc_score` to evaluate the model. This metric measures the area under the [receiver operating characteristic](https://en.wikipedia.org/wiki/Receiver_operating_characteristic) curve. Values closer to 1.0 are desirable."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -76,10 +76,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "`.dtypes` = list all the columns and the type of data in them"
    ]

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -417,7 +417,7 @@
     "from sklearn.metrics import mean_squared_error\n",
     "\n",
     "preds = xgb_reg.predict(taxi_test[features])\n",
-    "mean_squared_error(taxi_test[y_col], preds, squared=False)"
+    "mean_squared_error(taxi_test[target_col], preds, squared=False)"
    ]
   },
   {


### PR DESCRIPTION
This PR proposes some improvements for the XGBoost notebooks in `examples-cpu/nyc-taxi/`. It moves the list of features down to feature-generation code, so that when you open the notebook you aren't looking at that out-of-context code and wondering what it means.

This also adds some additional explanatory text.