### PR TITLE
add explanations in snowflake XGBoost notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -35,28 +35,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "numeric_feat = [\n",
-    "    \"pickup_weekday\",\n",
-    "    \"pickup_weekofyear\",\n",
-    "    \"pickup_hour\",\n",
-    "    \"pickup_week_hour\",\n",
-    "    \"pickup_minute\",\n",
-    "    \"passenger_count\",\n",
-    "]\n",
-    "categorical_feat = [\n",
-    "    \"pickup_taxizone_id\",\n",
-    "    \"dropoff_taxizone_id\",\n",
-    "]\n",
-    "features = numeric_feat + categorical_feat\n",
-    "y_col = \"tip_fraction\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -117,8 +95,7 @@
     "    scheduler_size=\"medium\",\n",
     "    worker_size=\"large\",\n",
     ")\n",
-    "client = Client(cluster)\n",
-    "cluster"
+    "client = Client(cluster)"
    ]
   },
   {
@@ -137,6 +114,33 @@
    "outputs": [],
    "source": [
     "client.wait_for_workers(n_workers=n_workers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Monitor Resource Usage\n",
+    "\n",
+    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "\n",
+    "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Click that dashboard link to view some diagnostic information about the Dask cluster. This can be used to view the current resource utilization of workers in the cluster and lots of information about what they're currently working on."
    ]
   },
   {
@@ -306,6 +310,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "numeric_feat = [\n",
+    "    \"pickup_weekday\",\n",
+    "    \"pickup_weekofyear\",\n",
+    "    \"pickup_hour\",\n",
+    "    \"pickup_week_hour\",\n",
+    "    \"pickup_minute\",\n",
+    "    \"passenger_count\",\n",
+    "]\n",
+    "categorical_feat = [\n",
+    "    \"pickup_taxizone_id\",\n",
+    "    \"dropoff_taxizone_id\",\n",
+    "]\n",
+    "features = numeric_feat + categorical_feat\n",
+    "y_col = \"tip_fraction\"\n",
+    "\n",
     "taxi_train = taxi[features + [y_col]].astype(float).fillna(-1)"
    ]
   },
@@ -322,7 +341,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Train a model\n",
+    "<hr>\n",
+    "\n",
+    "## Train a model\n",
     "\n",
     "This example uses the native Dask integration built into XGBoost. That integration was added in `xgboost` 1.3.0, and should be preferred to [`dask-xgboost`](https://github.com/dask/dask-xgboost)."
    ]
@@ -405,7 +426,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save model"
+    "<hr>\n",
+    "\n",
+    "## Save model\n",
+    "\n",
+    "`xgb.dask.train()` produces a regular `xgb.core.Booster` object, the same model object produced by non-Dask training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "booster = result[\"booster\"]\n",
+    "type(booster)\n",
+    "\n",
+    "# xgboost.core.Booster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once you've trained a model, save it in a file to use later for scoring or for comparison with other models.\n",
+    "\n",
+    "There are several ways to do this, but `cloudpickle` is likely to give you the best experience. It handles some common drawbacks of the built-in `pickle` library.\n",
+    "\n",
+    "`cloudpickle` can be used to write a Python object to bytes, and to create a Python object from that binary representation."
    ]
   },
   {
@@ -429,6 +477,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Calculate metrics on test set\n",
     "\n",
     "Use a different month for test set"

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -32,28 +32,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "numeric_feat = [\n",
-    "    \"pickup_weekday\",\n",
-    "    \"pickup_weekofyear\",\n",
-    "    \"pickup_hour\",\n",
-    "    \"pickup_week_hour\",\n",
-    "    \"pickup_minute\",\n",
-    "    \"passenger_count\",\n",
-    "]\n",
-    "categorical_feat = [\n",
-    "    \"pickup_taxizone_id\",\n",
-    "    \"dropoff_taxizone_id\",\n",
-    "]\n",
-    "features = numeric_feat + categorical_feat\n",
-    "y_col = \"tip_fraction\""
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -158,6 +136,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "numeric_feat = [\n",
+    "    \"pickup_weekday\",\n",
+    "    \"pickup_weekofyear\",\n",
+    "    \"pickup_hour\",\n",
+    "    \"pickup_week_hour\",\n",
+    "    \"pickup_minute\",\n",
+    "    \"passenger_count\",\n",
+    "]\n",
+    "categorical_feat = [\n",
+    "    \"pickup_taxizone_id\",\n",
+    "    \"dropoff_taxizone_id\",\n",
+    "]\n",
+    "features = numeric_feat + categorical_feat\n",
+    "y_col = \"tip_fraction\"\n",
+    "\n",
     "taxi_train = taxi[features + [y_col]].astype(float).fillna(-1)"
    ]
   },
@@ -174,9 +167,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Train a model\n",
+    "<hr>\n",
     "\n",
-    "Setting `n_jobs = multiprocessing.cpu_count()` tells xgboost it can use all available cores on this machine to complete training."
+    "## Train a Model\n",
+    "\n",
+    "Now that the data have been prepped, it's time to build a model!\n",
+    "\n",
+    "For this task, we'll use the `XGBRegressor` from `xgboost`. If you've never used XGBoost or need a refresher, see [the XGBoost Python docs](https://xgboost.readthedocs.io/en/latest/python/index.html).\n",
+    "\n",
+    "The code below initializes an `XGBRegressor` with the following parameter values.\n",
+    "\n",
+    "* `objective = \"reg:squarederror\"`: solve a regression problem, and use mean squared error as the loss function\n",
+    "* `tree_method = \"hist\"`: use the \"histogram\" method of building trees. This method sacrifices a small amount of training accuracy for much faster training time.\n",
+    "* `learning_rate = 0.1`: controls how much each new tree contributes to the overall model. 0.1 is an arbitrary value.\n",
+    "* `max_depth = 5`: stop growing a tree once it contains a leaf node that is 5 levels below the root\n",
+    "* `n_estimators = 50`: create a model with at most 50 trees\n",
+    "* `n_jobs = multiprocessing.cpu_count()`: use all available cores on this machine to parallelize training\n",
+    "* `verbosity = 1`: print INFO-level logs and above\n",
+    "\n",
+    "All other parameters use the defaults from [`XGBRegressor`](https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.XGBRegressor).\n",
+    "\n",
+    "<details><summary>(click here to learn why data scientists do this)</summary>\n",
+    "\n",
+    "**Setting max_depth**\n",
+    "    \n",
+    "Tree-based models split the training data into smaller and smaller groups, to try to group together records with similar values of the target. A tree can be thought of as a collection of rules like `pickup_hour greater than 11` and `pickup_minute less than 31.0`. As you add more rules, those groups (called \"leaf nodes\") get smaller. In an extreme example, a model could create a tree with enough rules to place each record in the training data into its own group. That would probably take a lot of rules, and would be referred to as a \"deep\" tree.\n",
+    "    \n",
+    "Deep trees are problematic because their descriptions of the world are too specific to be useful on new data. Imagine training a classification model to predict whether or not visitors to a theme park will ride a particular rollercoaster. You could measure the time down to the millisecond that every guest's ticket is scanned at the entrance, and a model might learn a rule like *\"if the guest has been to the park before and if the guest is older than 40 and younger than 41, and if the guest is staying at Hotel A and if the guest enters the park after 1:00:17.456 and if the guest enters the park earlier than 1:00:17.995, they will ride the rollercoaster\"*. This is very very unlikely to ever match any future visitors, and if it does it's unlikely that this prediction will be very good unless you have some reason to believe that a visitor arriving at 1:00:18 instead of 1:00:17 really changes the probability that they'll ride that rollercoaster.\n",
+    "    \n",
+    "To prevent this situation (called \"overfitting\"), most tree-based machine learning algorithms accept parameters that control how deep the trees can get. `max_depth` is common, and says \"don't create a rule more complex than this\". In the example above, that rule has a depth of 7.\n",
+    "    \n",
+    "1. visiting the park\n",
+    "2. has been to the park before?\n",
+    "3. older than 40?\n",
+    "4. younger than 41?\n",
+    "5. staying at Hotel A?\n",
+    "6. entered the park after 1:00:17.456?\n",
+    "7. entered the park before 1:00:17.995?\n",
+    "    \n",
+    "Setting `max_depth = 5` would have prevented those weirdly-specific timing rules from ever being generated.\n",
+    "    \n",
+    "Choosing good values for this parameter is part art, part science, and is outside the scope of this tutorial.\n",
+    "    \n",
+    "</details>"
    ]
   },
   {
@@ -200,6 +233,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the regressor created, fit it to some data! The code below uses `%%time` to print out a timing, so you can see how long it takes to train. This can be used to compare single-node, CPU `xgboost` to methods explored in other notebooks, or to test how changing some parameters changes the runtime for training.\n",
+    "\n",
+    "**NOTE:** This will take a few minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for this model to train."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -213,7 +255,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save model"
+    "<hr>\n",
+    "\n",
+    "## Save model\n",
+    "\n",
+    "Once you've trained a model, save it in a file to use later for scoring or for comparison with other models.\n",
+    "\n",
+    "There are several ways to do this, but `cloudpickle` is likely to give you the best experience. It handles some common drawbacks of the built-in `pickle` library.\n",
+    "\n",
+    "`cloudpickle` can be used to write a Python object to bytes, and to create a Python object from that binary representation."
    ]
   },
   {
@@ -237,9 +287,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<hr>\n",
+    "\n",
     "## Calculate metrics on test set\n",
     "\n",
-    "Use a different month for test set"
+    "Machine learning training tries to create a model which can produce useful results on new data that it didn't see during training. To test how well we've accomplished that in this example, read in another month of taxi data."
    ]
   },
   {
@@ -250,6 +302,15 @@
    "source": [
     "taxi_test = conn.cursor().execute(query, \"2019-02-01\").fetch_pandas_all()\n",
     "taxi_test.columns = taxi_test.columns.str.lower()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`scikit-learn` comes with many functions for calculating metrics that describe how well a model's predictions match the actual values. For a complete list, see [\"Metrics and scoring\"](https://scikit-learn.org/stable/modules/model_evaluation.html) in the `sciki-learn` docs.\n",
+    "\n",
+    "This tutorial uses the `mean_squared_error` to evaluate the model. This metric penalizes large errors more than small errors."
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -372,7 +372,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Train a model\n",
+    "<hr>\n",
+    "\n",
+    "## Train a model\n",
     "\n",
     "This example uses the native Dask integration built into XGBoost. That integration was added in `xgboost` 1.3.0, and should be preferred to [`dask-xgboost`](https://github.com/dask/dask-xgboost)."
    ]

--- a/examples/examples-cpu/nyc-taxi/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost.ipynb
@@ -19,7 +19,8 @@
     "\n",
     "> based on characteristics that can be known at the beginning of a trip, what tip will this trip earn (as a % of the total fare)?\n",
     "\n",
-    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."   ]
+    "**NOTE:** This notebook has some cells that can take 3-10 minutes to run. Consider opening [this Dask + XGBoost notebook](./xgboost-dask.ipynb) and running that while you're waiting for cells in this notebook to complete."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -410,7 +411,7 @@
    "source": [
     "`scikit-learn` comes with many functions for calculating metrics that describe how well a model's predictions match the actual values. For a complete list, see [\"Metrics and scoring\"](https://scikit-learn.org/stable/modules/model_evaluation.html) in the `sciki-learn` docs.\n",
     "\n",
-    "This tutorial uses the `roc_auc_score` to evaluate the model. This metric measures the area under the [receiver operating characteristic](https://en.wikipedia.org/wiki/Receiver_operating_characteristic) curve. Values closer to 1.0 are desirable."
+    "This tutorial uses the `mean_squared_error` to evaluate the model. This metric penalizes large errors more than small errors."
    ]
   },
   {


### PR DESCRIPTION
This PR fills out the snowflake XGBoost notebooks with similar details and descriptions to those added in #69. That includes a new section on resource monitoring.

This also fixes a mistake in the metric text from #69. Some notebooks previously mentioned `roc_auc_score` when they should have been talking about `mean_squared_error`.