### PR TITLE
remove language about GPUs in CPU-only notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -117,7 +117,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "This tutorial aims to teach you how to take advantage of multiple machines for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -122,7 +122,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
+    "This tutorial aims to teach you how to take advantage of multiple machines for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "This tutorial aims to teach you how to take advantage of multiple machines for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "### Monitor Resource Usage\n",
     "\n",
-    "This tutorial aims to teach you how to take advantage of multiple GPUs for data science workflows. To prove to yourself that Dask RAPIDS are utilizing the GPUs, it's important to understand how to monitor that utilization while your code is running. If you already know how to do that, skip to the next section.\n",
+    "This tutorial aims to teach you how to take advantage of multiple machines for data science workflows. To prove to yourself that Dask is taking advantage of the resources in the cluster, it's important to understand how to monitor that utilization while your code is running.\n",
     "\n",
     "Print the `cluster` object in a notebook renders a widget that shows the number of workers, available CPU and memory, and a dashboard link."
    ]


### PR DESCRIPTION
While working on https://github.com/saturncloud/workshop-lightgbm-dask, I copied a lot of stuff from the examples in this project. I realized this morning that the "Monitor Resources" section in the Dask `examples-cpu` notebooks has some language about GPUs, which is inaccurate. Probably something I accidentally copied over from the `examples-gpu` notebooks during the last round of concentrated effort on these notebooks.

This PR fixes that language.

### Notes for reviewers

This is NOT urgent and doesn't have to be merged before today's LightGBM workshop.