### PR TITLE
fix missing arg in feature engineering

### DIFF
--- a/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-dask.ipynb
@@ -465,7 +465,7 @@
     "    assume_missing=True,\n",
     ").sample(frac=0.01, replace=False)\n",
     "\n",
-    "taxi_test = prep_df(taxi_test)"
+    "taxi_test = prep_df(taxi_test, target_col=target_col)"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi/hyperparameter-scikit.ipynb
@@ -373,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_test = prep_df(taxi_test)"
+    "taxi_test = prep_df(taxi_test, target_col=target_col)"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi/xgboost-dask.ipynb
@@ -482,7 +482,7 @@
     "    assume_missing=True,\n",
     ").sample(frac=0.01, replace=False)\n",
     "\n",
-    "taxi_test = prep_df(taxi_test)"
+    "taxi_test = prep_df(taxi_test, target_col=target_col)"
    ]
   },
   {


### PR DESCRIPTION
In recent refactoring, `prep_df()` (the function used for feature engineering in these examples) was changed to take in an argument `target_col`, a string with the name of the target column.

Some calls to that function were not updated. This PR fixes that.