### PR TITLE
fix incorrect variable reference in rf-scikit Snowflake example

### DIFF
--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -182,10 +182,10 @@
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"high_tip\"\n",
     "\n",
-    "taxi = conn.cursor().execute(query, \"2019-01-01\")\n",
-    "columns = [x[0] for x in taxi.description]\n",
-    "taxi_train = pd.DataFrame(taxi.fetchall(), columns=columns)\n",
-    "taxi.columns = taxi.columns.str.lower()"
+    "query_result = conn.cursor().execute(query, \"2019-01-01\")\n",
+    "columns = [x[0] for x in query_result.description]\n",
+    "taxi_train = pd.DataFrame(query_result.fetchall(), columns=columns)\n",
+    "taxi_train.columns = taxi_train.columns.str.lower()"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Num rows: {len(taxi)}, Size: {taxi_train.memory_usage(deep=True).sum() / 1e6} MB\")"
+    "print(f\"Num rows: {len(taxi_train)}, Size: {taxi_train.memory_usage(deep=True).sum() / 1e6} MB\")"
    ]
   },
   {
@@ -398,11 +398,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi = conn.cursor().execute(query, \"2019-02-01\")\n",
-    "columns = [x[0] for x in taxi.description]\n",
-    "taxi = pd.DataFrame(taxi.fetchall(), columns=columns)\n",
-    "taxi.columns = taxi.columns.str.lower()\n",
-    "taxi_test = taxi"
+    "query_result = conn.cursor().execute(query, \"2019-02-01\")\n",
+    "columns = [x[0] for x in query_result.description]\n",
+    "taxi_test = pd.DataFrame(query_result.fetchall(), columns=columns)\n",
+    "taxi_test.columns = taxi_test.columns.str.lower()"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the following error in one of the snowflake notebooks:

```text
E           Exception: Non-zero exit code (1) from pod j-testd-examples-gpu-61459954e99644409f8f6917b52bf252-866fd97gp:
E           [NbConvertApp] Converting notebook nyc-taxi-snowflake/rf-scikit.ipynb to python
E           [NbConvertApp] Writing 13911 bytes to nyc-taxi-snowflake/rf-scikit-fb763d16-c78f-4b47-8255-05b38d390f79.py
E           ---------------------------------------------------------------------------
E           AttributeError                            Traceback (most recent call last)
E           ~/project/examples/nyc-taxi-snowflake/rf-scikit-fb763d16-c78f-4b47-8255-05b38d390f79.py in <module>
E               151 columns = [x[0] for x in taxi.description]
E               152 taxi_train = pd.DataFrame(taxi.fetchall(), columns=columns)
E           --> 153 taxi.columns = taxi.columns.str.lower()
E               154 
E               155 
E           
E           AttributeError: 'SnowflakeCursor' object has no attribute 'columns'
```

In `examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb`, the variable `taxi` is used to refer to a Snowflake query result, but there are some parts of the notebook that reference it as if it was a `pandas` DataFrame.

### How I tested this

I ran this notebook in a new `examples-gpu` project on `app.internal`, which uses the latest Saturn images.