### PR TITLE
fix xgboost-dask issue

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -529,7 +529,8 @@
    "source": [
     "from dask_ml.metrics import mean_squared_error\n",
     "\n",
-    "mean_squared_error(taxi_test[y_col].to_dask_array(), preds.to_dask_array(), squared=False)"
+    "with client as client:\n",
+    "    mean_squared_error(taxi_test[y_col].to_dask_array(), preds.to_dask_array(), squared=False)"
    ]
   },
   {


### PR DESCRIPTION
This fixes the issue where `dask_ml.metrics.mean_squared_error` in  `examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb` fails with this error

> ValueError: Inputs contain futures that were created by another client.