### PR TITLE
fix type mismatch in hyperparameter notebooks

### DIFF
--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb
@@ -238,6 +238,7 @@
     "    with snowflake.connector.connect(**conn_info) as conn:\n",
     "        taxi = conn.cursor().execute(query, str(day)).fetch_pandas_all()\n",
     "        taxi.columns = taxi.columns.str.lower()\n",
+    "        taxi = taxi.astype(float).fillna(-1)\n",
     "        return taxi"
    ]
   },
@@ -321,7 +322,7 @@
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"tip_fraction\"\n",
     "\n",
-    "taxi_train = taxi[features + [y_col]].astype(float).fillna(-1)"
+    "taxi_train = taxi[features + [y_col]]"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/hyperparameter-scikit.ipynb
@@ -291,7 +291,8 @@
    "outputs": [],
    "source": [
     "taxi_test = conn.cursor().execute(query, \"2019-02-01\").fetch_pandas_all()\n",
-    "taxi_test.columns = taxi_test.columns.str.lower()"
+    "taxi_test.columns = taxi_test.columns.str.lower()\n",
+    "taxi_test = taxi_test.astype(float).fillna(-1)"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost-dask.ipynb
@@ -244,6 +244,7 @@
     "    with snowflake.connector.connect(**conn_info) as conn:\n",
     "        taxi = conn.cursor().execute(query, str(day)).fetch_pandas_all()\n",
     "        taxi.columns = taxi.columns.str.lower()\n",
+    "        taxi = taxi.astype(float).fillna(-1)\n",
     "        return taxi"
    ]
   },
@@ -325,7 +326,7 @@
     "features = numeric_feat + categorical_feat\n",
     "y_col = \"tip_fraction\"\n",
     "\n",
-    "taxi_train = taxi[features + [y_col]].astype(float).fillna(-1)"
+    "taxi_train = taxi[features + [y_col]]"
    ]
   },
   {

--- a/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
+++ b/examples/examples-cpu/nyc-taxi-snowflake/xgboost.ipynb
@@ -301,7 +301,8 @@
    "outputs": [],
    "source": [
     "taxi_test = conn.cursor().execute(query, \"2019-02-01\").fetch_pandas_all()\n",
-    "taxi_test.columns = taxi_test.columns.str.lower()"
+    "taxi_test.columns = taxi_test.columns.str.lower()\n",
+    "taxi_test = taxi_test.astype(float).fillna(-1)"
    ]
   },
   {

--- a/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
+++ b/examples/examples-gpu/nyc-taxi-snowflake/rf-scikit.ipynb
@@ -410,7 +410,8 @@
    "outputs": [],
    "source": [
     "taxi_test = conn.cursor().execute(query, \"2019-02-01\").fetch_pandas_all()\n",
-    "taxi_test.columns = taxi_test.columns.str.lower()"
+    "taxi_test.columns = taxi_test.columns.str.lower()\n",
+    "taxi_test = taxi_test.astype(float).fillna(-1)"
    ]
   },
   {


### PR DESCRIPTION
### Changes in this PR

For all of the `examples-cpu` snowflake notebooks, moves conversion of datasets to `float` into the delayed function that is used to execute Snowflake queries. This ensures that the data types are identical for both training and test data.

### Background

We've observed that often, but not always, the call to `dask_ml.model_selection.GridSearchCV.predict()` fails with an error whose stack trace ends like this:

```text
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/internals/managers.py in _slice_take_blocks_ax0()
E              1345                 )
E              1346             else:
E           -> 1347                 blk = self.blocks[blkno]
E              1348 
E              1349                 # Otherwise, slicing along items axis is necessary.
E           
E           IndexError: tuple index out of range
```

<details><summary>full log (click me)</summary>

```text
E           ---------------------------------------------------------------------------
E           IndexError                                Traceback (most recent call last)
E           ~/project/examples/nyc-taxi-snowflake/hyperparameter-dask-ae35f30a-a169-4706-8e67-b892535dd8d0.py in <module>
E               346 from sklearn.metrics import mean_squared_error
E               347 
E           --> 348 preds = grid_search.predict(taxi_test[features])
E               349 mean_squared_error(taxi_test[y_col], preds, squared=False)
E               350 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/utils/metaestimators.py in <lambda>(*args, **kwargs)
E               117 
E               118         # lambda, but not partial, allows help() to work with update_wrapper
E           --> 119         out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
E               120         # update the docstring of the returned function
E               121         update_wrapper(out, self.fn)
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask_ml/model_selection/_search.py in predict(self, X)
E              1125     def predict(self, X):
E              1126         self._check_is_fitted("predict")
E           -> 1127         return self.best_estimator_.predict(X)
E              1128 
E              1129     @if_delegate_has_method(delegate=("best_estimator_", "estimator"))
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/utils/metaestimators.py in <lambda>(*args, **kwargs)
E               117 
E               118         # lambda, but not partial, allows help() to work with update_wrapper
E           --> 119         out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
E               120         # update the docstring of the returned function
E               121         update_wrapper(out, self.fn)
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/pipeline.py in predict(self, X, **predict_params)
E               406         for _, name, transform in self._iter(with_final=False):
E               407             Xt = transform.transform(Xt)
E           --> 408         return self.steps[-1][-1].predict(Xt, **predict_params)
E               409 
E               410     @if_delegate_has_method(delegate='_final_estimator')
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/linear_model/_base.py in predict(self, X)
E               234             Returns predicted values.
E               235         """
E           --> 236         return self._decision_function(X)
E               237 
E               238     _preprocess_data = staticmethod(_preprocess_data)
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/linear_model/_coordinate_descent.py in _decision_function(self, X)
E               884                                    dense_output=True) + self.intercept_
E               885         else:
E           --> 886             return super()._decision_function(X)
E               887 
E               888 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/linear_model/_base.py in _decision_function(self, X)
E               216         check_is_fitted(self)
E               217 
E           --> 218         X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
E               219         return safe_sparse_dot(X, self.coef_.T,
E               220                                dense_output=True) + self.intercept_
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/utils/validation.py in inner_f(*args, **kwargs)
E                70                           FutureWarning)
E                71         kwargs.update({k: arg for k, arg in zip(sig.parameters, args)})
E           ---> 72         return f(**kwargs)
E                73     return inner_f
E                74 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/sklearn/utils/validation.py in check_array(array, accept_sparse, accept_large_sparse, dtype, order, copy, force_all_finite, ensure_2d, allow_nd, ensure_min_samples, ensure_min_features, estimator)
E               596                     array = array.astype(dtype, casting="unsafe", copy=False)
E               597                 else:
E           --> 598                     array = np.asarray(array, order=order, dtype=dtype)
E               599             except ComplexWarning:
E               600                 raise ValueError("Complex data not supported\n"
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/numpy/core/_asarray.py in asarray(a, dtype, order)
E                81 
E                82     """
E           ---> 83     return array(a, dtype, copy=False, order=order)
E                84 
E                85 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/core.py in __array__(self, dtype, **kwargs)
E               369 
E               370     def __array__(self, dtype=None, **kwargs):
E           --> 371         self._computed = self.compute()
E               372         x = np.array(self._computed)
E               373         return x
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/base.py in compute(self, **kwargs)
E               165         dask.base.compute
E               166         """
E           --> 167         (result,) = compute(self, traverse=False, **kwargs)
E               168         return result
E               169 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/base.py in compute(*args, **kwargs)
E               450         postcomputes.append(x.__dask_postcompute__())
E               451 
E           --> 452     results = schedule(dsk, keys, **kwargs)
E               453     return repack([f(r, *a) for r, (f, a) in zip(results, postcomputes)])
E               454 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/client.py in get(self, dsk, keys, restrictions, loose_restrictions, resources, sync, asynchronous, direct, retries, priority, fifo_timeout, actors, **kwargs)
E              2723                     should_rejoin = False
E              2724             try:
E           -> 2725                 results = self.gather(packed, asynchronous=asynchronous, direct=direct)
E              2726             finally:
E              2727                 for f in futures.values():
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/client.py in gather(self, futures, errors, direct, asynchronous)
E              1990                 direct=direct,
E              1991                 local_worker=local_worker,
E           -> 1992                 asynchronous=asynchronous,
E              1993             )
E              1994 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/client.py in sync(self, func, asynchronous, callback_timeout, *args, **kwargs)
E               831         else:
E               832             return sync(
E           --> 833                 self.loop, func, *args, callback_timeout=callback_timeout, **kwargs
E               834             )
E               835 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/utils.py in sync(loop, func, callback_timeout, *args, **kwargs)
E               338     if error[0]:
E               339         typ, exc, tb = error[0]
E           --> 340         raise exc.with_traceback(tb)
E               341     else:
E               342         return result[0]
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/utils.py in f()
E               322             if callback_timeout is not None:
E               323                 future = asyncio.wait_for(future, callback_timeout)
E           --> 324             result[0] = yield future
E               325         except Exception as exc:
E               326             error[0] = sys.exc_info()
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/tornado/gen.py in run(self)
E               760 
E               761                     try:
E           --> 762                         value = future.result()
E               763                     except Exception:
E               764                         exc_info = sys.exc_info()
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/distributed/client.py in _gather(self, futures, errors, direct, local_worker)
E              1849                             exc = CancelledError(key)
E              1850                         else:
E           -> 1851                             raise exception.with_traceback(traceback)
E              1852                         raise exc
E              1853                     if errors == "skip":
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/optimization.py in __call__()
E               959         if not len(args) == len(self.inkeys):
E               960             raise ValueError("Expected %d args, got %d" % (len(self.inkeys), len(args)))
E           --> 961         return core.get(self.dsk, self.outkey, dict(zip(self.inkeys, args)))
E               962 
E               963     def __reduce__(self):
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in get()
E               149     for key in toposort(dsk):
E               150         task = dsk[key]
E           --> 151         result = _execute_task(task, cache)
E               152         cache[key] = result
E               153     result = _execute_task(out, cache)
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in _execute_task()
E               119         # temporaries by their reference count and can execute certain
E               120         # operations in-place.
E           --> 121         return func(*(_execute_task(a, cache) for a in args))
E               122     elif not ishashable(arg):
E               123         return arg
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in <genexpr>()
E               119         # temporaries by their reference count and can execute certain
E               120         # operations in-place.
E           --> 121         return func(*(_execute_task(a, cache) for a in args))
E               122     elif not ishashable(arg):
E               123         return arg
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in _execute_task()
E               119         # temporaries by their reference count and can execute certain
E               120         # operations in-place.
E           --> 121         return func(*(_execute_task(a, cache) for a in args))
E               122     elif not ishashable(arg):
E               123         return arg
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in <genexpr>()
E               119         # temporaries by their reference count and can execute certain
E               120         # operations in-place.
E           --> 121         return func(*(_execute_task(a, cache) for a in args))
E               122     elif not ishashable(arg):
E               123         return arg
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/core.py in _execute_task()
E               119         # temporaries by their reference count and can execute certain
E               120         # operations in-place.
E           --> 121         return func(*(_execute_task(a, cache) for a in args))
E               122     elif not ishashable(arg):
E               123         return arg
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/utils.py in apply()
E                27 def apply(func, args, kwargs=None):
E                28     if kwargs:
E           ---> 29         return func(*args, **kwargs)
E                30     else:
E                31         return func(*args)
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/core.py in apply_and_enforce()
E              5296     func = kwargs.pop("_func")
E              5297     meta = kwargs.pop("_meta")
E           -> 5298     df = func(*args, **kwargs)
E              5299     if is_dataframe_like(df) or is_series_like(df) or is_index_like(df):
E              5300         if not len(df):
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/methods.py in try_loc()
E                40     """
E                41     try:
E           ---> 42         return loc(df, iindexer, cindexer)
E                43     except KeyError:
E                44         return df.head(0).loc[:, cindexer]
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/dask/dataframe/methods.py in loc()
E                28         return df.loc[iindexer]
E                29     else:
E           ---> 30         return df.loc[iindexer, cindexer]
E                31 
E                32 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/indexing.py in __getitem__()
E               871                     # AttributeError for IntervalTree get_value
E               872                     pass
E           --> 873             return self._getitem_tuple(key)
E               874         else:
E               875             # we by definition only have the 0th axis
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/indexing.py in _getitem_tuple()
E              1053             return self._multi_take(tup)
E              1054 
E           -> 1055         return self._getitem_tuple_same_dim(tup)
E              1056 
E              1057     def _get_label(self, label, axis: int):
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/indexing.py in _getitem_tuple_same_dim()
E               748                 continue
E               749 
E           --> 750             retval = getattr(retval, self.name)._getitem_axis(key, axis=i)
E               751             # We should never have retval.ndim < self.ndim, as that should
E               752             #  be handled by the _getitem_lowerdim call above.
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/indexing.py in _getitem_axis()
E              1097                     raise ValueError("Cannot index with multidimensional key")
E              1098 
E           -> 1099                 return self._getitem_iterable(key, axis=axis)
E              1100 
E              1101             # nested tuple slicing
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/indexing.py in _getitem_iterable()
E              1037         keyarr, indexer = self._get_listlike_indexer(key, axis, raise_missing=False)
E              1038         return self.obj._reindex_with_indexers(
E           -> 1039             {axis: [keyarr, indexer]}, copy=True, allow_dups=True
E              1040         )
E              1041 
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/generic.py in _reindex_with_indexers()
E              4519                 fill_value=fill_value,
E              4520                 allow_dups=allow_dups,
E           -> 4521                 copy=copy,
E              4522             )
E              4523             # If we've made a copy once, no need to make another one
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/internals/managers.py in reindex_indexer()
E              1247 
E              1248         if axis == 0:
E           -> 1249             new_blocks = self._slice_take_blocks_ax0(indexer, fill_value=fill_value)
E              1250         else:
E              1251             new_blocks = [
E           
E           /opt/conda/envs/saturn/lib/python3.7/site-packages/pandas/core/internals/managers.py in _slice_take_blocks_ax0()
E              1345                 )
E              1346             else:
E           -> 1347                 blk = self.blocks[blkno]
E              1348 
E              1349                 # Otherwise, slicing along items axis is necessary.
E           
E           IndexError: tuple index out of range
```

</details>

This doesn't happen every time you run `predict()`, but I observed that it never went more than 3 consecutive successful calls.

I found the relevant code from `pandas`. https://github.com/pandas-dev/pandas/blob/83479e1efc3cdbe31d8042eebaed8a6a90bb3b1c/pandas/core/internals/managers.py#L1322-L1330

This is really really deep in the `pandas` internals so I haven't walked back up to something user-facing so that I can explain this. But I can tell from the variable names that is something that relies on knowledge of how the data frame is chunked in memory (referred to as `blk` for "block" in that code).

I was trying to figure out what could affect some code like that. I tried different numbers of partitions, different data shapes (i.e. "lots of columns" or "lots of rows"), and different types. Then I realized accidentally that we have a line in this notebook that changes the types of the training data.

```python
taxi_train = taxi[features + [y_col]].astype(float).fillna(-1)
```

That code is not repeated on the `taxi_test` dataset a few lines down, so that seemed like a relevant difference! Adding a `.astype(float)` to `taxi_test` eliminated the error :grinning: . Note that at the point this code is called, `taxi` is a DaskDataFrame.

### How I tested this

To both find this error and confirm it was fixed, I tried 10 consecutive calls to `GridSearchCV.predict()`. I ran this at the end of the  notebook `examples-cpu/nyc-taxi-snowflake/hyperparameter-dask.ipynb`. I ran this on the Saturn app.daily cluster today, with no other modifications to the environment.

```python
from sklearn.metrics import mean_squared_error

for i in range(10):
    print(i)
    preds = grid_search.predict(taxi_test[features])
    mean_squared_error(taxi_test[y_col], preds, squared=False)
```

### Root Cause

So my theory about what happened:

* `dask-ml` trained some `ElasticNet` models on an all-float dataset
* somewhere in the model object, it saved that fact that the column types were floats
* when we passed in a dataset that had some int columns, pandas tried to seek along blocks of the underlying dataframes ASSUMING THEY WERE FLOATS. This led to a size mismatch that led to the error.

That idea doesn't really explain why this error would be random though. So :man_shrugging: .

I tried to create a reproducible example to share in `dask-ml`, but so far I haven't been able to reproduce this outside of the hyperparameter-dask notebook. Here's how far I got:

<details><summary>reproducible example</summary>

```python
import dask
from dask.distributed import Client, wait
from dask_saturn import SaturnCluster

n_workers = 3
cluster = SaturnCluster(
    n_workers=n_workers,
    scheduler_size="medium",
    worker_size="large",
)
client = Client(cluster)

import numpy as np

from sklearn.pipeline import Pipeline
from sklearn.linear_model import ElasticNet
from dask_ml.compose import ColumnTransformer
from dask_ml.preprocessing import StandardScaler, DummyEncoder, Categorizer
from dask_ml.model_selection import GridSearchCV

import dask.dataframe as dd
import dask.array as da
import pandas as pd
import numpy as np

NUM_PARTITIONS = 28

def _create_data() -> pd.DataFrame:
    num_rows = 1000
    return pd.DataFrame({
        "target_col": pd.Series(np.random.random(num_rows), dtype="float64"),
        "int8_col": pd.Series(np.random.choice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], num_rows), dtype="int8"),
        "int16_col": pd.Series(np.random.choice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], num_rows), dtype="int16")
    })

parts = [dask.delayed(_create_data)() for _ in range(NUM_PARTITIONS)]
ddf = dd.from_delayed(
    parts,
)
ddf = ddf.persist()
_ = wait(ddf)

ddf = ddf.astype(float).fillna(-1)

categorical_feat = ["int16_col"]
numeric_feat = ["int8_col"]
features = categorical_feat + numeric_feat

test_pipeline = Pipeline(
    steps=[
        ("categorize", Categorizer(columns=categorical_feat)),
        ("onehot", DummyEncoder(columns=categorical_feat)),
        (
            "scale",
            ColumnTransformer(
                transformers=[("num", StandardScaler(), numeric_feat)],
                remainder="passthrough",
            ),
        ),
        ("clf", ElasticNet(normalize=False, max_iter=10)),
    ]
)

params = {
    "clf__l1_ratio": [0.1, 0.2],
    "clf__alpha": [1, 2],
}

test_search = GridSearchCV(test_pipeline, params, cv=3, scoring="neg_mean_squared_error")

_ = test_search.fit(ddf[features], ddf["target_col"])
test_search.best_score_

test_ddf = dd.from_delayed(
    [dask.delayed(_create_data)() for _ in range(NUM_PARTITIONS)],
)

for i in range(10):
    print(i)
    preds = test_search.predict(test_ddf[features])
```

</details>
