### PR TITLE
Add template fields to examples-cpu and examples-gpu

### DIFF
--- a/examples/examples-cpu/.saturn/saturn.json
+++ b/examples/examples-cpu/.saturn/saturn.json
@@ -23,5 +23,8 @@
         "EXAMPLE_SNOWFLAKE_PASSWORD",
         "PREFECT_USER_TOKEN"
     ],
-    "description": "Examples for using Saturn Cloud. Includes Dask and Prefect tutorials, an end-to-end data science pipeline, and more."
+    "description": "Dask and Prefect tutorials, an end-to-end data science pipeline, and more.",
+    "title": "CPU Examples",
+    "thumbnail_image_url": "https://s3-us-east-2.amazonaws.com/saturn-public-files/saturn-2x1.png",
+    "weight": 100
 }

--- a/examples/examples-gpu/.saturn/saturn.json
+++ b/examples/examples-gpu/.saturn/saturn.json
@@ -22,5 +22,5 @@
     "description": "GPU-accelerated machine learning model training with RAPIDS",
     "title": "GPU Examples",
     "thumbnail_image_url": "https://s3-us-east-2.amazonaws.com/saturn-public-files/saturn-2x1.png",
-    "weight": 101,
+    "weight": 101
 }

--- a/examples/examples-gpu/.saturn/saturn.json
+++ b/examples/examples-gpu/.saturn/saturn.json
@@ -19,5 +19,8 @@
         "EXAMPLE_SNOWFLAKE_USER",
         "EXAMPLE_SNOWFLAKE_PASSWORD"
     ],
-    "description": "Examples for using Saturn Cloud with GPUs. Includes GPU-accelerated machine learning model training with RAPIDS."
+    "description": "GPU-accelerated machine learning model training with RAPIDS",
+    "title": "GPU Examples",
+    "thumbnail_image_url": "https://s3-us-east-2.amazonaws.com/saturn-public-files/saturn-2x1.png",
+    "weight": 101,
 }


### PR DESCRIPTION
This is the stop-gap referred to in #109. With this in, we can merge #110.