### PR TITLE
Add whitespace-before colon ignore

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,5 @@ ignore =
     E722,
     # do not assign a lambda expression
     E731
+    # let black handle whitespace before ':'
+    E203


### PR DESCRIPTION
We do this in other Saturn codebases and it is motivated by https://github.com/PyCQA/pycodestyle/issues/373

The repercussions are we get things like:

```diff
-    pet_names_padded = [name[-(str_len + 1):] for name in pet_names_characters]
+    pet_names_padded = [name[-(str_len + 1) :] for name in pet_names_characters]

```