### PR TITLE
made instances correct for freemium

### DIFF
--- a/examples/dashboard/.saturn/saturn.json
+++ b/examples/dashboard/.saturn/saturn.json
@@ -1,7 +1,7 @@
 {
     "image": "saturncloud/saturn:2021.02.22",
     "jupyter": {
-        "size": "medium",
+        "size": "large",
         "disk_space": "10Gi",
         "ssh_enabled": false
     },

--- a/examples/dask/.saturn/saturn.json
+++ b/examples/dask/.saturn/saturn.json
@@ -1,14 +1,14 @@
 {
     "image": "saturncloud/saturn:2021.02.22",
     "jupyter": {
-        "size": "xlarge",
+        "size": "large",
         "disk_space": "10Gi",
         "ssh_enabled": false
     },
     "dask_cluster": {
         "n_workers": 3,
-        "scheduler_size": "medium",
-        "worker_size": "xlarge"
+        "scheduler_size": "large",
+        "worker_size": "large"
     },
     "environment_variables": {},
     "description": "Use distributed computing with Dask",

--- a/examples/data-science-pipeline/.saturn/saturn.json
+++ b/examples/data-science-pipeline/.saturn/saturn.json
@@ -7,7 +7,7 @@
     },
     "dask_cluster": {
         "n_workers": 3,
-        "scheduler_size": "medium",
+        "scheduler_size": "large",
         "worker_size": "large",
         "nthreads": 2
     },

--- a/examples/prefect/.saturn/saturn.json
+++ b/examples/prefect/.saturn/saturn.json
@@ -7,7 +7,7 @@
     },
     "dask_cluster": {
         "n_workers": 3,
-        "scheduler_size": "medium",
+        "scheduler_size": "large",
         "worker_size": "large",
         "nthreads": 2
     },

--- a/examples/pytorch/.saturn/saturn.json
+++ b/examples/pytorch/.saturn/saturn.json
@@ -7,7 +7,7 @@
     },
     "dask_cluster": {
         "n_workers": 3,
-        "scheduler_size": "medium",
+        "scheduler_size": "large",
         "worker_size": "g4dnxlarge"
     },
     "environment_variables": {

--- a/examples/rapids/.saturn/saturn.json
+++ b/examples/rapids/.saturn/saturn.json
@@ -8,7 +8,7 @@
     "dask_cluster": {
         "n_workers": 3,
         "nthreads": 1,
-        "scheduler_size": "medium",
+        "scheduler_size": "large",
         "worker_size": "g4dnxlarge"
     },
     "environment_variables": {},


### PR DESCRIPTION
This PR standardizes all the quickstarts to use either "large" or "g4dnxlarge" for all the instances (including the scheduler). This will make us conform with the freemium requirements, and should make maintaining these easier.

Some of the examples currently will break in freemium since they require instances that are not allowed, so ideally we would roll out a solution fairly quickly.