### PR TITLE
add CI job to check for broken links

### DIFF
--- a/.ci/check-links.sh
+++ b/.ci/check-links.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# [description]
+#     look for external links in code, and check if any of them
+#     are broken
+#
+# [usage]
+#
+#     ./pdc/scripts/dev/check-links.sh frontend/src
+#
+
+set -u -o pipefail
+
+SOURCE_TO_CHECK=$1
+
+# get all unique external links, with some exceptions
+#
+# * links to private resources
+# * local resources
+# * links that are templated and require evaluation of code
+#
+URLS=$(
+    grep \
+        -R \
+        -o \
+        --binary-files=without-match \
+        --no-filename \
+        -E '(http|https)://[^"` )>,\\]+' \
+        "${SOURCE_TO_CHECK}" \
+    | grep -v '\$' \
+    | grep -v '{' \
+    | grep -v -E '\:[0-9]+$' \
+    | grep -v 'auth.docker.io' \
+    | grep -v 'demo.saturnenterprise.io' \
+    | grep -v "https://github.com/saturncloud/docs/" \
+    | grep -v -E "(http|https)://[0-9]+" \
+    | grep -v 'localhost.' \
+    | grep -v 'localtest.' \
+    | sed 's/\.$//g' \
+    | sort -u
+)
+
+echo "Checking URLs in ${SOURCE_TO_CHECK}"
+
+ISSUES_FOUND=0
+for url in ${URLS}; do
+    printf "  * %s ..." "${url}"
+    if curl \
+        --output /dev/null \
+        --silent \
+        --head \
+        --retry 3 \
+        --fail \
+        -H "From: dev@saturncloud.io" \
+        -H "User-Agent: saturn-cloud-automation" \
+        "${url}";
+    then
+        printf "OK\n"
+        continue
+    else
+        printf "ERROR\n"
+        ISSUES_FOUND=$((ISSUES_FOUND + 1))
+    fi
+done
+
+echo ""
+echo "Done checking URLs in ${SOURCE_TO_CHECK}. Found ${ISSUES_FOUND} issues."
+echo ""
+
+exit $ISSUES_FOUND

--- a/.ci/check-links.sh
+++ b/.ci/check-links.sh
@@ -6,7 +6,7 @@
 #
 # [usage]
 #
-#     ./pdc/scripts/dev/check-links.sh frontend/src
+#     ./.ci/check-links.sh $(pwd)
 #
 
 set -u -o pipefail

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,19 @@
+name: link checks
+
+on:
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
+  # Run once a day at 8:00am UTC
+  schedule:
+    - cron: '0 8 * * *'
+
+jobs:
+  check-links:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: check links
+        run: |
+          make check-links

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 SHELL=/bin/bash
 
+.PHONY: check-links
+check-links:
+	./.ci/check-links.sh $$(pwd)
+
 .PHONY: format
 format:
 	black .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Example projects
 
+[![link checks](https://github.com/saturncloud/examples/workflows/link%20checks/badge.svg?branch=main)](https://github.com/saturncloud/examples/actions/workflows/check-links.yml)
+
 These are the quickstart projects available in Saturn cloud. Each project has a set of files to include on workspace machine when the project is started, as well as parameters for how the workspace should be set up. The parameters include the number of machines for a Dask cluster, if any, the size of the machines, and a start script to run when they are first turn on. If you would like to use code from one of these projects, select the quickstart options from within Saturn Cloud.
 
-In addition to be used as quickstarts, many of the [Saturn Cloud docs](http://saturncloud.io/docs) pull directly from these notebooks. The docs pull in the notebooks using a manually run script [`make_md.py`](https://github.com/saturncloud/docs/blob/main/make_md.py) from the [docs repo](https://github.com/saturncloud/docs).
+In addition to be used as quickstarts, many of the [Saturn Cloud docs](http://saturncloud.io/docs) pull directly from these notebooks. The docs pull in the notebooks using a manually run script [`make_md.py`](https://github.com/saturncloud/docs/blob/main/make_md.py) from the [docs repo](https://github.com/saturncloud/docs/).
 
 **Note: this repo includes the existing legacy `examples-cpu` and `examples-gpu`. This is for compatibility with existing enterprise customers, and will be deprecated in the future**
 


### PR DESCRIPTION
This PR proposes adding a continuous integration job that will scrape all the external links out of the source code in this repo and check that they're valid.

To be respectful of other sites and to avoid introducing friction into the PR process in this project, this PR proposes that this new check be run once a day, NOT on every pull request.

As of this change, it will also be possible to manually run this job any time you want from https://github.com/saturncloud/examples/actions.

### How to test this

To test manually, pull this branch and run

```shell
make check-links
```

