### PR TITLE
fixed image html

### DIFF
--- a/examples/pytorch/03-start-with-pytorch-dask-multiple-models.ipynb
+++ b/examples/pytorch/03-start-with-pytorch-dask-multiple-models.ipynb
@@ -252,7 +252,7 @@
   },
   {
    "source": [
-    "<img src = \"/https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-resources/pytorch-dask-experiment-output.png\" width = 600px alt=\"Experimental results from PyTorch\">"
+    "<img src = \"https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-resources/pytorch-dask-experiment-output.png\" width = 600px alt=\"Experimental results from PyTorch\" class=\"doc-image\">"
    ],
    "cell_type": "markdown",
    "metadata": {}


### PR DESCRIPTION
One quickstart had a badly formatted url (plus was missing the doc-image class we need when loading it into the docs).