### PR TITLE
use different flow names in Prefect Cloud examples

### DIFF
--- a/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
+++ b/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Flow(f\"{SATURN_USERNAME}-ticket-model-evaluation\", schedule=schedule) as flow:\n",
+    "with Flow(f\"{SATURN_USERNAME}-example-ticket-model-evaluation\", schedule=schedule) as flow:\n",
     "    batch_size = Parameter(\"batch-size\", default=1000)\n",
     "    trial_id = get_trial_id()\n",
     "\n",


### PR DESCRIPTION
This PR proposes choosing the default flow name chosen for the Prefect Cloud flow created in https://github.com/saturncloud/examples/blob/4fab3f0c599753874896d711c3cb918eb3cc88be/examples/examples-cpu/prefect/prefect-cloud-scheduled-scoring.ipynb.

The name isn't an important part of the user experience with these examples, but having different names between that file and its twin, https://github.com/saturncloud/examples/blob/4fab3f0c599753874896d711c3cb918eb3cc88be/examples/prefect/02-prefect-cloud.ipynb, is important to reduce the risk of integration test runs of those two notebooks interfering with each other.