### PR TITLE
include nvdashboard in rapids example

### DIFF
--- a/examples/rapids/.saturn/start
+++ b/examples/rapids/.saturn/start
@@ -1,0 +1,2 @@
+/srv/conda/bin/pip install jupyterlab-nvdashboard==0.5.0
+/srv/conda/bin/jupyter labextension install jupyterlab-nvdashboard


### PR DESCRIPTION
This install jupyterlab-nvdashboard as part of the start script to allow using this nice JupyterLab widget to monitor GPU utilization. This is just for the Jupyter server's GPU, for GPUs in a Dask cluster, the Dask widget already does it
![image](https://user-images.githubusercontent.com/8964039/120546762-43956980-c3be-11eb-8f62-156948deb268.png)
