### PR TITLE
Changed references to projects to instead be resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ When you add a new example, add an entry to [`CODEOWNERS`](./.github/CODEOWNERS)
 
 Examples in this the `examples/` directory follow a specific directory structure that allows Saturn to automatically seed them in a new user's environment with these.
 
-Each directory below `examples/` corresponds to one new Saturn Project + Jupyter server that will be created in users' environments. Those projects will be named using the directory name, so the names of these directories should have names which only contain lowercase alphanumeric characters and dashes.
+Each directory below `examples/` corresponds to one new resource that will be created in users' environments. Those resources will be named using the directory name, so the names of these directories should have names which only contain lowercase alphanumeric characters and dashes.
 
 ```text
 examples/
@@ -112,7 +112,7 @@ A JSON with the following structure:
     - `ssh_enabled`: A boolean indicating whether to set up [SSH access from outside Saturn into the Server](https://www.saturncloud.io/docs/tips-and-tricks/ssh/)
 * `environment_variables`:
     - A dictionary whose keys are the names of environment variables, and whose values are the values for the environment variables.
-* `description`: plain text explaining what the project does
+* `description`: plain text explaining what the resource does
 
 Any customization of Dask clusters should be done in notebook code, using [`dask-saturn`](https://github.com/saturncloud/dask-saturn).
 
@@ -122,7 +122,7 @@ A shell script that will be run on startup of the Jupyter server and all Dask re
 
 # Releasing
 
-Releases of this project follow releases of Saturn Cloud.
+Releases of this repository follow releases of Saturn Cloud.
 
 When it is time to cut a new release, follow these steps:
 
@@ -143,16 +143,16 @@ This repo has a branch protection to prevent deletion or changes without a pull 
 
 #### Can I include other code or add more sub-directories under and example in the `examples/` directory?
 
-All other directories included under the example directory will be included in the example, and an arbitrary amount of nesting is permitted.
+All other directories included under the example directory will be included in the example, and an arbitrary amount of nesting is permitted. Non-code files such as data should be stored on S3.
 
 #### What do I do if my example needs a custom image?
 
-All images referenced in an example's `.saturn/saturn.json` should be publicly available on Docker Hub. This project does not handle building new images.
+All images referenced in an example's `.saturn/saturn.json` should be publicly available on Docker Hub. This repository does not handle building new images.
 
 If you need a new image, you can make a pull request in https://github.com/saturncloud/images to add it.
 
-#### Why does this project use long-lived release branches instead of GitHub releases and tags on `main`?
+#### Why does this repository use long-lived release branches instead of GitHub releases and tags on `main`?
 
-Using long-lived release branches allows for the possiblility of hotfixing older versions of this project if issues arise.
+Using long-lived release branches allows for the possiblility of hotfixing older versions of this repository if issues arise.
 
-Releases of this project are intended to be tightly coupled to releases of Saturn's main product. Releasing a version of Saturn's main product with code that says "grab the latest commit from a particular branch" allows us to release hotfixes without needing to interrupt any running Saturn installations.
+Releases of this repository are intended to be tightly coupled to releases of Saturn's main product. Releasing a version of Saturn's main product with code that says "grab the latest commit from a particular branch" allows us to release hotfixes without needing to interrupt any running Saturn installations.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Example projects
+# Saturn Cloud Default Resources
 
 [![link checks](https://github.com/saturncloud/examples/workflows/link%20checks/badge.svg?branch=main)](https://github.com/saturncloud/examples/actions/workflows/check-links.yml)
 
-These are the quickstart projects available in Saturn cloud. Each project has a set of files to include on workspace machine when the project is started, as well as parameters for how the workspace should be set up. The parameters include the number of machines for a Dask cluster, if any, the size of the machines, and a start script to run when they are first turn on. If you would like to use code from one of these projects, select the quickstart options from within Saturn Cloud.
+These are the Saturn Cloud Default Resources that populate admin accounts and cannot be deleted. They are used to power template resources (which can turned on or off by Saturn Cloud admins). Each example has a set of files to include on workspace machine when the resource is started, as well as parameters for how the resource should be set up. These parameters match those which users set when creating new resources. If you would like to use code from one of these resources, select one of the template resources from the resource page of Saturn Cloud.
 
-In addition to be used as quickstarts, many of the [Saturn Cloud docs](http://saturncloud.io/website) pull directly from these notebooks. The docs pull in the notebooks using a manually run script [`make_md.py`](https://github.com/saturncloud/website/blob/main/make_md.py) from the [website repo](https://github.com/saturncloud/website/).
+In addition to be used as template resources, many of the [Saturn Cloud docs](http://saturncloud.io/website) pull directly from these notebooks. The docs pull in the notebooks using a manually run script [`make_md.py`](https://github.com/saturncloud/website/blob/main/make_md.py) from the [website repo](https://github.com/saturncloud/website/).
 
 **Note: this repo includes the existing legacy `examples-cpu` and `examples-gpu`. This is for compatibility with existing enterprise customers, and will be deprecated in the future**
 
-## Project structure
+## Resource structure
 
-Each project is a separate folder within the `examples` folder. For each project there is one subfolder called `.saturn` which contains the information specific to the Saturn Cloud project. Everything not within a `.saturn` folder will be available within the workspace machine of the project in Saturn Cloud.
+Each resource is a separate folder within the `examples` folder. For each resource there is one subfolder called `.saturn` which contains the information specific to the Saturn Cloud resource. Everything not within a `.saturn` folder will be available within the resource in Saturn Cloud.
 
 The most important file within the `.saturn` folder is the `saturn.json` file which includes setup parameters. Here is an example of a `saturn.json` file:
 
@@ -38,9 +38,9 @@ The most important file within the `.saturn` folder is the `saturn.json` file wh
 }
 ```
 
-It's possible that other files might existing in the .saturn folder, such as `start` which contains the initialization script for the project. However, no file besides `saturn.json` is required.
+It's possible that other files might existing in the .saturn folder, such as `start` which contains the initialization script for the resource. However, no file besides `saturn.json` is required.
 
-Notes about the project structure:
+Notes about the resource structure:
 
 * The disk_space must be one of the preset choices from the Saturn Cloud UI, it can't be an arbitrary amount of disk space.
 * The startup script must be name `start` without a file extension for Atlas to know it.

--- a/examples/dask/README.md
+++ b/examples/dask/README.md
@@ -1,5 +1,5 @@
 # Distributed Computing Quickstart
 
-This project lets you quickly get starting running computations across multiple systems using Dask. The project is set up to have a single workspace instance (which is hosting this notebook), and three additional Dask workers for doing distributed computations. To get started with Dask, check out the [start-with-dask.ipybnb](start-with-dask.ipybnb) notebook, which shows how you can take a parallelizable Python function and run it on multiple systems at once.
+This resource lets you quickly get starting running computations across multiple systems using Dask. The resource is set up to have a single workspace instance (which is hosting this notebook), and three additional Dask workers for doing distributed computations. To get started with Dask, check out the [start-with-dask.ipybnb](start-with-dask.ipybnb) notebook, which shows how you can take a parallelizable Python function and run it on multiple systems at once.
 
 _For more details about the basics of Dask, read the [Parallelization in Python](https://www.saturncloud.io/docs/reference/dask_concepts/) article in the Saturn Cloud docs._ You can also look at the [Saturn Cloud Dask examples](https://www.saturncloud.io/docs/examples/dask/), and [the official Dask documentation](https://docs.dask.org/en/latest/).

--- a/examples/dask/start-with-dask.ipynb
+++ b/examples/dask/start-with-dask.ipynb
@@ -1,10 +1,10 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
    "source": [
     "# Getting started with Dask on Saturn Cloud"
    ],
-   "cell_type": "markdown",
    "metadata": {
     "execution": {
      "iopub.execute_input": "2021-03-10T17:00:41.290664Z",
@@ -17,23 +17,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "\n",
     "Dask is a framework that easily lets you run Python in parallel across distributed machines. Below is a small example of using Dask on Saturn Cloud. The code creates a function that computes exponents and runs it across a list of inputs in parallel.\n",
     "\n",
     "_For more details about the basics of Dask, read the [Parallelization in Python](https://www.saturncloud.io/docs/reference/dask_concepts/) article in the Saturn Cloud docs._ You can also look at the [Saturn Cloud Dask examples](https://www.saturncloud.io/docs/examples/dask/), and [the official Dask documentation](https://docs.dask.org/en/latest/).\n",
     "\n",
-    "Before running this example, you need to create a Dask cluster associated with this project. You can create the cluster through the [Saturn Cloud project page](https://www.saturncloud.io/docs/getting-started/create_cluster_ui/), or [programmatically in Python](https://www.saturncloud.io/docs/getting-started/create_cluster/#create-clustersaturncluster-object).\n",
+    "Before running this example, you need to [create a Dask cluster](https://www.saturncloud.io/docs/using-saturn-cloud/create_dask_cluster/) associated with this resource\n",
     "\n",
     "This code chunk imports the Dask libraries and connects to the Saturn Cloud Dask cluster. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import dask\n",
     "from dask_saturn import SaturnCluster\n",
@@ -41,31 +39,32 @@
     "\n",
     "cluster = SaturnCluster()\n",
     "client = Client(cluster)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "You can use the `@dask.delayed` decorator to change a regular Python function into a lazily-evaluated function. That means that a function call will return a future, instead of a value. The function won't immediately do the computation when it is run, instead only when that future object has its result requested."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "@dask.delayed\n",
     "def lazy_exponent(args):\n",
     "    x, y = args\n",
     "    \"\"\"Define a lazily evaluating function\"\"\"\n",
     "    return x ** y"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The Dask distributed client comes with several methods for managing collections of such futures. The code below shows how to use a few of these.\n",
     "\n",
@@ -75,13 +74,12 @@
     "* `.result()` - Wait for a future to complete. Returns its actual value.\n",
     "\n",
     "All together, the code below will take the list of inputs, converts them to futures held by Dask workers for apply the exponental function, gathers them onto the client machine, and determines the results."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "inputs = [[1, 2], [3, 4], [5, 6], [9, 10], [11, 12]]\n",
     "\n",
@@ -91,26 +89,28 @@
     "\n",
     "results = [x.result() for x in futures_computed]\n",
     "results"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This was _somewhat_ of a toy example--you probably want to do more complex computations than exponents with Dask. However the core concept of making a function and then running it in a distributed fashion is at the core of what you can do with Dask on Saturn Cloud.\n",
     "\n",
     "\n",
     "When you're done, you can close the connection to the cluster:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "client.close()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/data-science-pipeline/README.md
+++ b/examples/data-science-pipeline/README.md
@@ -35,7 +35,7 @@ To run as part of a persistent Deployment check out the [Saturn Cloud docs](http
 
 ## Aggregate data files
 
-Saturn Cloud hosts pre-aggregated NYC taxi data from 2017-2019 for the dashboard in the previous step. The [`data-aggregation.ipynb`](data-aggregation.ipynb) notebook contains all the code to perform these aggregations. It is set up to run on a small sample (first few months of 2017) to be able to be executed in this example project. This notebook is included to illustrate how Dask is used with a Saturn cluster for data processing, but the files generated here will not be used by any of the other examples. 
+Saturn Cloud hosts pre-aggregated NYC taxi data from 2017-2019 for the dashboard in the previous step. The [`data-aggregation.ipynb`](data-aggregation.ipynb) notebook contains all the code to perform these aggregations. It is set up to run on a small sample (first few months of 2017) to be able to be executed in this example. This notebook is included to illustrate how Dask is used with a Saturn cluster for data processing, but the files generated here will not be used by any of the other examples. 
 
 ## Train ML models
 
@@ -73,7 +73,7 @@ You'll notice that there is not much code to change here beyond launching the Da
 
 ### Random forest classification
 
-The random forest examples showcase GPU-accelerated model training with [RAPIDS](http://rapids.ai/). This requires a separate project running on a GPU instance and image. Jump over to the `examples-gpu` project on your Jupyter page for these examples.
+The random forest examples showcase GPU-accelerated model training with [RAPIDS](http://rapids.ai/). This requires a separate resource running on a GPU instance and image.
 
 ## Serve ML model
 

--- a/examples/examples-r/README.md
+++ b/examples/examples-r/README.md
@@ -3,7 +3,7 @@
 # Start Using R in Saturn Cloud
 ## Welcome to Saturn Cloud!
 
-This project gives you an environment ready for conducting data science in R in Jupyter. Open a new notebook and select the R kernel to begin.
+This resource gives you an environment ready for conducting data science in R in Jupyter. Open a new notebook and select the R kernel to begin.
 
 The following packages and all of their `Imports`, `Depends`, and `LinkingTo` dependencies are included in the image.
 
@@ -33,6 +33,6 @@ R is not compatible with Dask or Dask clusters, so you will not be able to take 
 
 ## Next steps
 
-Thanks for trying out this project! To learn more about how Saturn Cloud works, check out our [Documentation](https://www.saturncloud.io/docs/), [blog](https://www.saturncloud.io/s/blog/), or join an [upcoming event](https://www.saturncloud.io/s/events/).
+Thanks for trying out this resource! To learn more about how Saturn Cloud works, check out our [Documentation](https://www.saturncloud.io/docs/), [blog](https://www.saturncloud.io/s/blog/), or join an [upcoming event](https://www.saturncloud.io/s/events/).
 
-If you have any questions or suggestions for example projects, reach out to us at support@saturncloud.io or open an issue on the [examples Github repo](https://github.com/saturncloud/examples).
+If you have any questions or suggestions reach out to us at support@saturncloud.io or open an issue on the [examples Github repo](https://github.com/saturncloud/examples).

--- a/examples/prefect/02-prefect-cloud.ipynb
+++ b/examples/prefect/02-prefect-cloud.ipynb
@@ -2,14 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Use Prefect Cloud with Saturn Cloud"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<table>\n",
     "    <tr>\n",
@@ -40,11 +39,11 @@
     "This dataset can be used to solve a regression task:\n",
     "\n",
     "> Given the characteristics of a ticket, how long will it be until it is closed?"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -60,13 +59,12 @@
     "* `scikit-learn`: evaluation metric functions\n",
     "* `dask-saturn`: create and interact with Saturn Cloud `Dask` clusters ([link](https://github.com/saturncloud/dask-saturn))\n",
     "* `prefect-saturn`: register Prefect flows with both Prefect Cloud and have them run on Saturn Cloud Dask clusters ([link](https://github.com/saturncloud/prefect-saturn))"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import json\n",
     "import numpy as np\n",
@@ -90,27 +88,28 @@
     "\n",
     "PREFECT_CLOUD_PROJECT_NAME = os.environ[\"PREFECT_CLOUD_PROJECT_NAME\"]\n",
     "SATURN_USERNAME = os.environ[\"SATURN_USERNAME\"]"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Authenticate with Prefect Cloud."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "!prefect auth login -t ${PREFECT_USER_TOKEN}"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -119,21 +118,21 @@
     "Prefect Cloud organizes flows within workspaces called \"projects\". Before you can register a flow with Prefect Cloud, it's necessary to create a project if you don't have one yet.\n",
     "\n",
     "The code below will create a new project in whatever Prefect Cloud tenant you're authenticated with. If that project already exists, this code does not have any side effects."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "client = prefect.Client()\n",
     "client.create_project(project_name=PREFECT_CLOUD_PROJECT_NAME)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -154,13 +153,12 @@
     "* `evaluate_model()`: compute evaluation metrics comparing predicted and actual time-to-close\n",
     "* `get_trial_summary()`: collect all evaluation metrics in one object\n",
     "* `write_trial_summary()`: write trial results somewhere"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "@task\n",
     "def get_trial_id() -> str:\n",
@@ -266,11 +264,12 @@
     "    \"\"\"\n",
     "    logger = prefect.context.get(\"logger\")\n",
     "    logger.info(json.dumps(trial_summary))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -287,29 +286,28 @@
     "> * An acyclic directed graph has no circular dependencies: if you walk through the graph, you will never revisit a task you've seen before.\n",
     "\n",
     "Because we want this job to run on a schedule, the code below provides one additional argument to `Flow()`, a special \"schedule\" object. In this case, the code below says \"run this flow once every 24 hours\"."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "schedule = IntervalSchedule(interval=timedelta(hours=24))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "*NOTE: `prefect` flows do not have to be run on a schedule. To test a single run, just omit `schedule` from the code block below.*"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "with Flow(f\"{SATURN_USERNAME}-ticket-model-evaluation\", schedule=schedule) as flow:\n",
     "    batch_size = Parameter(\"batch-size\", default=1000)\n",
@@ -340,38 +338,39 @@
     "\n",
     "    # store trial summary\n",
     "    trial_complete = write_trial_summary(trial_summary)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "At this point, we have all of the work defined in tasks and arranged within a flow, but none of the tasks have run yet. In the next section, we'll do that using `Dask`."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
     "## Register with Prefect Cloud\n",
     "\n",
     "Now that the business logic of the flow is complete, we can add information that Saturn will need to know to run it."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "integration = PrefectCloudIntegration(prefect_cloud_project_name=PREFECT_CLOUD_PROJECT_NAME)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Next, run `register_flow_with_saturn().\n",
     "\n",
@@ -387,13 +386,12 @@
     "    - **NOTE**: you can find the full list of sizes with `prefect_saturn.describe_sizes()`\n",
     "* `autoclose = False`: leave the Dask cluster running after the flow run finishes\n",
     "* `worker_is_spot = False`: don't use spot instances for workers"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "flow = integration.register_flow_with_saturn(\n",
     "    flow=flow,\n",
@@ -405,27 +403,28 @@
     "        \"worker_is_spot\": False,\n",
     "    },\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "The final step necessary is to \"register\" the flow with Prefect Cloud. If this is the first time you've registered this flow, it will create a new flow in Prefect Cloud under the project in `PREFECT_CLOUD_PROJECT_NAME`. If you already have a flow in this project with this name, it will create a new version of it in Prefect Cloud."
-   ]
+    "The final step necessary is to \"register\" the flow with Prefect Cloud. If this is the first time you've registered this flow, it will create a new Prefect Cloud project `PREFECT_CLOUD_PROJECT_NAME`. If you already have a flow in this project with this name, it will create a new version of it in Prefect Cloud."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "flow.register(project_name=PREFECT_CLOUD_PROJECT_NAME)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -445,11 +444,11 @@
     "    --name ${SATURN_USERNAME}-ticket-model-evaluation \\\n",
     "    --project ${PREFECT_CLOUD_PROJECT_NAME}\n",
     "```"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -462,7 +461,8 @@
     "If you have existing prefect flows, try running one of them on Saturn using this notebook as a template.\n",
     "\n",
     "<hr>"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/pytorch/01-start-with-pytorch.ipynb
+++ b/examples/pytorch/01-start-with-pytorch.ipynb
@@ -2,16 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Getting Started with PyTorch on Saturn Cloud\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "This example shows how you can use the power of a GPU to quickly train a neural network in Saturn Cloud. This code runs on a single GPU within the Jupyterlab of a Saturn Cloud project.\n",
+    "This example shows how you can use the power of a GPU to quickly train a neural network in Saturn Cloud. This code runs on a single GPU of a Jupyter server resource.\n",
     "\n",
     "This is an example of a natural language processing neural network which is trained on Seattle pet license data to then generate new pet names. The model uses LSTM layers which are especially good at discovering patterns in sequences like text. The model takes a partially complete name and determines the probability of each possible next character in the name. Characters are randomly sampled from this distribution and added to the partial name until a stop character is generated and full name has been created.\n",
     "\n",
@@ -20,13 +19,12 @@
     "This code downloads the already cleaned pet names data, creates functions to process it into a format to feed into an LSTM, and defines the model architecture.\n",
     "\n",
     "First, import the required modules:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import uuid  # noqa\n",
     "import datetime\n",
@@ -39,20 +37,20 @@
     "import urllib.request\n",
     "import pandas as pd  # noqa\n",
     "from torch.utils.data import Dataset, DataLoader"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "This chunk downloads the pet names data, then defines functions and classes to help process and manage the data. It also defines the model architecture for the LSTM."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "with urllib.request.urlopen(\n",
     "    \"https://saturn-public-data.s3.us-east-2.amazonaws.com/examples/pytorch/seattle_pet_licenses_cleaned.json\"\n",
@@ -124,21 +122,21 @@
     "        output, state = self.lstm(x)\n",
     "        logits = self.fc(output)\n",
     "        return logits"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Train the model\n",
     "We define a `train()` function that will do the work to train the neural network. This function should be called once and will return the trained model. It will use the `torch.device(0)` command to access the GPU."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def train():\n",
     "    device = torch.device(0)\n",
@@ -165,29 +163,30 @@
     "            f\"{datetime.datetime.now().isoformat()} - epoch {epoch} complete - loss {loss.item()}\"\n",
     "        )\n",
     "    return model"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The next block of code actually runs the training function and creates the trained model."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "num_epochs = 8\n",
     "batch_size = 4096\n",
     "model = train()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "After each epoch you should see a line of output like:\n",
     "\n",
@@ -196,13 +195,12 @@
     "## Generating Names\n",
     "\n",
     "To generate names, we have a function that takes the model and runs it over and over on a string, generating each new character until a stop character is met."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def generate_name(model, characters, str_len):\n",
     "    device = torch.device(0)\n",
@@ -244,30 +242,31 @@
     "    # turn the list of characters into a single string\n",
     "    pet_name = \"\".join(in_progress_name).title()\n",
     "    return pet_name"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Finally, let's generate 50 names! Also let's remove any names that would have shown up in the training data since those are less fun."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# Generate 50 names then filter out existing ones\n",
     "generated_names = [generate_name(model, characters, str_len) for i in range(0, 50)]\n",
     "generated_names = [name for name in generated_names if name not in pet_names]\n",
     "print(generated_names)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "After running the code above you should see a list of names like:\n",
     "\n",
@@ -281,7 +280,8 @@
     "```\n",
     "\n",
     "We have now trained a neural network using PyTorch on a GPU, and used it for inference! If we wanted to experiment with trying many different hyperparameters for the model we could concurrently train models with different hyperparameters using distributed computing. We could also train a single neural network over many GPUs at once with distributed computed. These scenarios are covered using Dask, a distributed computing framework, in the other PyTorch Saturn Cloud examples."
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/pytorch/02-start-with-dask.ipynb
+++ b/examples/pytorch/02-start-with-dask.ipynb
@@ -1,26 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
    "source": [
     "# Getting Started with Dask on Saturn Cloud"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "Dask is a framework that easily lets you run Python in parallel across distributed machines. Below is an example of taking a function that computes exponents and running it across a list of inputs in parallel.\n",
     "\n",
-    "This code imports the Dask libraries and connects to the Saturn Cloud Dask cluster. If you are having issues with this, you may not have a running Dask cluster, you can adjust the Dask cluster on the project page."
+    "This code imports the Dask libraries and connects to the Saturn Cloud Dask cluster. If you are having issues with this, you may not have a [running Dask cluster](https://saturncloud.io/docs/using-saturn-cloud/create_dask_cluster/), you can adjust the Dask cluster on the resource page."
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import dask\n",
     "from dask_saturn import SaturnCluster\n",
@@ -30,40 +28,40 @@
     "cluster = SaturnCluster(n_workers=n_workers)\n",
     "client = Client(cluster)\n",
     "client.wait_for_workers(n_workers)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The `@dask.delayed` decorator indicates this will run lazily in parallel:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "@dask.delayed\n",
     "def lazy_exponent(args):\n",
     "    x, y = args\n",
     "    \"\"\"Define a lazily evaluating function\"\"\"\n",
     "    return x ** y"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "With this Dask function, we can now run the function across a distributed set of workers using the `client` functions. In this case we take thios list of pairs of numbers and run them in a distributed setting. After using `client.compute()` to actually compute the values (since they're otherwise lazy) we can then look at the results by using `x.result()` for each element of the computed list:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "inputs = [[1, 2], [3, 4], [5, 6], [9, 10], [11, 12]]\n",
     "\n",
@@ -73,27 +71,29 @@
     "\n",
     "results = [x.result() for x in futures_computed]\n",
     "results"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "You should see a result of `[1, 81, 15625, 3486784401, 3138428376721]`.\n",
     "\n",
     "This was _somewhat_ of a toy example--you probably want to do more complex computations than exponents with Dask. However the core concept of making a function and then running it in a distributed fashion is at the core of what you can do with Dask on Saturn Cloud.\n",
     "\n",
     "When you're done, you can close the connection to the cluster:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "client.close()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/examples/pytorch/README.md
+++ b/examples/pytorch/README.md
@@ -1,6 +1,6 @@
 # PyTorch Quickstart
 
-This project provides the basics for using PyTorch on Saturn Cloud. The project is set to have a workspace server with GPU, and three workers in a Dask cluster, each with their own GPU. Here are some examples notebooks that walk through using a GPU with PyTorch, using Dask, then using Dask and PyTorch together across multiple workers:
+This resource provides the basics for using PyTorch on Saturn Cloud. The resource is set to have a workspace server with GPU, and three workers in a Dask cluster, each with their own GPU. Here are some examples notebooks that walk through using a GPU with PyTorch, using Dask, then using Dask and PyTorch together across multiple workers:
 
 ## [Use Pytorch on a single GPU](01-start-with-pytorch.ipynb)
 

--- a/examples/rapids/README.md
+++ b/examples/rapids/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-resources/rapids.png" width="400">
 
-This project provides the basics for using [RAPIDS](https://rapids.ai/) on Saturn Cloud. The project is set to have a workspace server with a GPU, and three workers in a Dask cluster, each with their own GPU. Here are some example notebooks that walk through using a GPU with RAPIDS, scaling to a cluster with Dask, then some runtime comparisons:
+This resource provides the basics for using [RAPIDS](https://rapids.ai/) on Saturn Cloud. The resource is set to have a workspace server with a GPU, and three workers in a Dask cluster, each with their own GPU. Here are some example notebooks that walk through using a GPU with RAPIDS, scaling to a cluster with Dask, then some runtime comparisons:
 
 ## [Use RAPIDS on a single GPU](01-rapids-gpu.ipynb)
 

--- a/examples/snowflake/snowflake-dask.ipynb
+++ b/examples/snowflake/snowflake-dask.ipynb
@@ -2,14 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Load Data from Snowflake into Saturn Cloud"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Our users have varied needs for loading data, but Snowflake is a very popular choice for data storage. This tutorial will give you foundational information to load data from Snowflake into Saturn Cloud quickly and easily.\n",
     "\n",
@@ -18,35 +17,34 @@
     "This notebook shows how to connect to a Snowflake database and do large data manipulations that would require distributed computing using Dask. We will use the NYC Taxi dataset hosted in a Saturn Cloud Snowflake database.\n",
     "\n",
     "First, we import the necessary libraries:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "import snowflake.connector\n",
     "import pandas as pd"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "> Don't worry if you see a warning about an incompatible version of pyarrow installed. This is because `snowflake.connector` relies on a older version of pyarrow for certain methods. We won't use those methods here so it's not a problem!\n",
     "\n",
     "Next, we connect to the Snowflake database using the Snowflake connector module. Here we are loading the credentials as environment variables using the Saturn Cloud credential manager, however you could [load them in other ways too](https://www.saturncloud.io/docs/getting-started/credentials/). Be sure not to save them as plaintext in unsafe places!\n",
     "\n",
     "## Connection Setup"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "conn_info = {\n",
     "    \"account\": os.environ[\"EXAMPLE_SNOWFLAKE_ACCOUNT\"],\n",
@@ -56,22 +54,22 @@
     "}\n",
     "\n",
     "conn = snowflake.connector.connect(**conn_info)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Snowflake Connector (pandas)\n",
     "\n",
     "We can run queries directly on a Snowflake database and load them into a pandas DataFrame. In the following cell we run a query to determine which days had a least one taxi ride in January 2019."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "dates_query = \"\"\"\n",
     "SELECT\n",
@@ -83,11 +81,12 @@
     "dates = pd.read_sql(dates_query, conn)[\"DATE\"].tolist()\n",
     "\n",
     "print(dates[0:5])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "\n",
@@ -95,16 +94,15 @@
     "\n",
     "When data sizes exceed what can fit into a single pandas DataFrame, we can read larger datasets into Dask DataFrames.\n",
     "\n",
-    "To use Dask with Snowflake, first we import the required modules and connect to the Dask cluster on Saturn Cloud. For this code to run you need to [start the Dask cluster from the project page of Saturn Cloud](https://saturncloud.io/docs/examples/dask/create_cluster_ui/).\n",
+    "To use Dask with Snowflake, first we import the required modules and connect to the Dask cluster on Saturn Cloud. For this code to run you need to [start the Dask cluster from the resource page of Saturn Cloud](https://saturncloud.io/docs/examples/dask/create_cluster_ui/).\n",
     "\n",
     "### Start the Cluster"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import dask.dataframe as dd\n",
     "import dask\n",
@@ -113,20 +111,20 @@
     "\n",
     "cluster = SaturnCluster()\n",
     "client = Client(cluster)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Next, we define a function that will query a small part of the data. Here we query information about a single day of taxi rides. We will run this query for each day separately and using all the Dask workers to run the queries and store the results. The `@dask.delayed` indicates that this function will be run over the Dask cluster. (For more information about delayed functions, check out [the Dask documentation](https://docs.dask.org/en/latest/).)"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "@dask.delayed\n",
     "def load_from_snowflake(day):\n",
@@ -142,70 +140,72 @@
     "        # that the missing data is properly filled\n",
     "        df.CONGESTION_SURCHARGE = df.CONGESTION_SURCHARGE.astype(\"float64\")\n",
     "        return df"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We create a list of all the results from running this query in a distributed way over all the days. As you can see from the `delayed_obs[:5]` call, these aren't pandas dataframes that are returned, they are Dask objects. The queries haven't actually be run yet, since Dask is lazy they won't be run until they are needed.\n",
     "\n",
     "The list of delayed observations can be turned into a single Dask Dataframe using `.from_delayed()`. A Dask DataFrame performs just liked a pandas DataFrame, they can use similar function calls and share a similar syntax, however the Dask DataFrame is actually a collection of pandas dataframes all distributed across a Dask cluster.\n",
     "\n",
     "## Pull Data"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "delayed_obs = [load_from_snowflake(day) for day in dates]\n",
     "delayed_obs[:5]\n",
     "\n",
     "dask_data = dd.from_delayed(delayed_obs)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We can see the contents of the DataFrame by using the same `.head()` call on the Dask DataFrame as we would on the pandas DataFrame."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "dask_data.head()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To actually cause the lazy computations to run, such as when finding the sum of a column in pandas, for Dask we need to end with `.computed()` or `.persist()`"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "dask_data[\"TOLLS_AMOUNT\"].sum().compute()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<hr>\n",
     "As you can see, by using Dask we are able to store data across multiple machines and run distributed calculations, all while using the same syntax as pandas. Depending on the size and type of data you are working with it may make more sense to either use pandas directly or Dask instead!"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is no changes to any of the functionality of the examples, just changes the text to remove any notion of a "project"