### PR TITLE
[ci] update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 # offer a reasonable automatic best-guess
 
 # catch-all rule (this only gets matched if no rules below match)
-*    @rikturr @skirmer @jnolis
+*    @skirmer @jnolis
 
-.ci/*    @jameslamb @jsignell
-.github/*    @jameslamb @jsignell
-Makefile    @jameslamb @jsignell
+.ci/*     @jsignell
+.github/*    @jsignell
+Makefile    @jsignell


### PR DESCRIPTION
👋 Hello friends!

Similar to https://github.com/saturncloud/prefect-saturn/pull/51. I've been getting email notifications recently due to this repo's [failing link-check builds](https://github.com/saturncloud/examples/actions).

I'm not sure if that's related to the fact that my username is still in the `CODEOWNERS`, but either way I think my username (and @rikturr 's) should be removed.

Could you also please check the repo settings and remove me from the collaborators for this repo if I'm listed there?

Thanks!