### PR TITLE
removed seed parameter

### DIFF
--- a/examples/snowflake/advanced/rf-rapids-dask.ipynb
+++ b/examples/snowflake/advanced/rf-rapids-dask.ipynb
@@ -475,7 +475,7 @@
    "source": [
     "from cuml.dask.ensemble import RandomForestClassifier\n",
     "\n",
-    "rfc = RandomForestClassifier(n_estimators=100, max_depth=10, seed=42)"
+    "rfc = RandomForestClassifier(n_estimators=100, max_depth=10)"
    ]
   },
   {


### PR DESCRIPTION
What is this change, and why is it needed?
cuML regression forest no longer uses parameter seed. Hence have removed that . 

