### PR TITLE
Run CI on a click

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -1,7 +1,10 @@
 name: Continuous Integration
 
-# alwas run CI on new commits to any branch
-on: push
+on:
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
+  # always run CI on new commits to any branch
+  push:
 
 jobs:
   test:


### PR DESCRIPTION
It turns out that you cannot trigger an action to run automatically when the event that would trigger it was triggered by an action. So this PR just adds the ability to run CI whenever you want via a button. Another solution is to push an empty commit to the automatically generated PR.

Note that this is an intentional behavior of github actions to prevent accidental infinite loops. 