### PR TITLE
Remove reference before opening PR

### DIFF
--- a/.ci/update-references.py
+++ b/.ci/update-references.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-REF = sys.argv[1]
+REF = sys.argv[1] if len(sys.argv) == 2 else None
 
 
 for file in os.listdir("examples"):
@@ -11,7 +11,10 @@ for file in os.listdir("examples"):
     with open(recipe_path) as f:
         recipe = json.load(f)
         for repo_dict in recipe["git_repositories"]:
-            repo_dict["reference"] = REF
+            if REF:
+                repo_dict["reference"] = REF
+            else:
+                repo_dict.pop("reference", None)
 
     with open(recipe_path, "w") as f:
         f.write(json.dumps(recipe, indent=2))

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,23 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Remove reference from recipe files
+      run: python .ci/update-references.py
+    - name: Diff recipes
+      id: diff
+      run: echo "::set-output name=result::$(git diff --quiet . || echo 'true')"
+    - name: Commit new files
+      if: ${{ steps.diff.outputs.result }}
+      run: |
+        git config --global user.name "saturn-automation"
+        git config --global user.email "automation@saturncloud.io"
+        git add *.json
+        git commit -m "Remove reference in every recipe"
+        git push origin ${{ github.ref }}:refs-main-${{ github.job }}
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
@@ -26,5 +42,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pr_title: "Update main from release"
         pr_body: ":rocket: *An automated PR* - Please make any changes needed to resolve merge conflicts and then approve and merge!"
-        pr_reviewer: "forana,${{ github.actor }}"
-        pr_draft: true
+        pr_reviewer: "forana,jsignell,${{ github.actor }}"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,8 +38,9 @@ jobs:
     - name: pull-request
       uses: repo-sync/pull-request@v2
       with:
+        source_branch: refs-main-${{ github.job }}
         destination_branch: "main"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         pr_title: "Update main from release"
-        pr_body: ":rocket: *An automated PR* - Please make any changes needed to resolve merge conflicts and then approve and merge!"
+        pr_body: ":rocket: *An automated PR* - Please make any changes needed to resolve merge conflicts and then approve and merge (don't squash merge)!"
         pr_reviewer: "forana,jsignell,${{ github.actor }}"


### PR DESCRIPTION
https://github.com/saturncloud/examples/pull/187 is an example of how the PR opening infra works right now. It'd be nice to automatically push a commit that removes the references again. 

I know this seems like we are going in circles, but it's important that every commit that is on a release branch is also included on main.