### PR TITLE
Fix example-job to point to actual dir

### DIFF
--- a/examples/example-job/.saturn/saturn.json
+++ b/examples/example-job/.saturn/saturn.json
@@ -2,7 +2,7 @@
   "name": "example-job",
   "image_uri": "saturncloud/saturn:2021.09.20",
   "description": "Run a job on Saturn Cloud. Read more about jobs at: https://scld.io/docs/deployments .",
-  "working_directory": "/home/jovyan/git-repos/examples/examples/jobs",
+  "working_directory": "/home/jovyan/git-repos/examples/examples/example-job",
   "git_repositories": [
     {
       "url": "https://github.com/saturncloud/examples",


### PR DESCRIPTION
We just missed this as part of #190 