### PR TITLE
Match dask worker instance type to workspace instance_type

### DIFF
--- a/.ci/validate-examples.py
+++ b/.ci/validate-examples.py
@@ -81,6 +81,15 @@ def validate_recipe(schema, recipe_path):
         if recipe["dask_cluster"]["num_workers"] > 3:
             raise ValidationError("there should not be more than 3 workers per dask cluster.")
 
+        jupyter = recipe.get("jupyter_server")
+        deployment = recipe.get("deployment")
+        workspace = jupyter or deployment
+        if recipe["dask_cluster"]["worker"]["instance_type"] != workspace["instance_type"]:
+            raise ValidationError(
+                "Dask worker instance type should match the instance type "
+                "of its attached jupyter_server or deployment"
+            )
+
 
 def image_exists_on_dockerhub(image_name: str, image_tag: str) -> bool:
     """

--- a/.ci/validate-examples.py
+++ b/.ci/validate-examples.py
@@ -83,7 +83,8 @@ def validate_recipe(schema, recipe_path):
 
         jupyter = recipe.get("jupyter_server")
         deployment = recipe.get("deployment")
-        workspace = jupyter or deployment
+        job = recipe.get("job")
+        workspace = jupyter or deployment or job
         if recipe["dask_cluster"]["worker"]["instance_type"] != workspace["instance_type"]:
             raise ValidationError(
                 "Dask worker instance type should match the instance type "

--- a/examples/snowflake-ml/.saturn/saturn.json
+++ b/examples/snowflake-ml/.saturn/saturn.json
@@ -21,7 +21,7 @@
   "dask_cluster": {
     "num_workers": 3,
     "worker": {
-      "instance_type": "large"
+      "instance_type": "g4dnxlarge"
     },
     "scheduler": {
       "instance_type": "large"

--- a/examples/snowflake/.saturn/saturn.json
+++ b/examples/snowflake/.saturn/saturn.json
@@ -20,7 +20,7 @@
   "dask_cluster": {
     "num_workers": 3,
     "worker": {
-      "instance_type": "large"
+      "instance_type": "g4dnxlarge"
     },
     "scheduler": {
       "instance_type": "large"


### PR DESCRIPTION
Fix for integration-test failure:
https://github.com/saturncloud/release-images/runs/4187812666?check_suite_focus=true

Dask workers were supposed to be running on GPU hardware, but were running on CPU hardware instead. Added validation to ensure dask worker instance_type matches that of its workspace.