### PR TITLE
Validate against specific version of recipes repo

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
+      REF: $([[ ${{github.event}} = 'pull_request' ]] && echo ${{github.base_ref}} || ${{echo github.ref}})
     strategy:
       fail-fast: false
       matrix:
@@ -45,5 +45,6 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
-          echo env.REF
+          echo ${{env.REF}}
+          echo ${{github.base_ref}}
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: release-2021.10.26 # ${{ github.base_ref || github.ref_name }}
+      REF: ${{ github.base_ref || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: $([[ ${{github.event}} = 'pull_request' ]] && echo ${{github.base_ref}} || ${{echo github.ref}})
+      REF: $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
     strategy:
       fail-fast: false
       matrix:
@@ -47,4 +47,5 @@ jobs:
           pip install --upgrade requests jsonschema
           echo ${{env.REF}}
           echo ${{github.base_ref}}
+          echo $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: ${{ github.base_ref || github.ref_name }}
+      REF: ${{ github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,12 +40,14 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
-          echo ${{env.REF}}
+          echo examples branch: ${{env.REF}}
+          echo recipe schema branch: ${{env.BRANCH}}
           python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch ${{ env.BRANCH }}
       - name : validate
         if: ${{ matrix.task == 'validating-examples' && !contains(env.REF, 'release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
-          echo ${{env.REF}}
+          echo examples branch: ${{env.REF}}
+          echo recipe schema branch: main
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -34,14 +34,14 @@ jobs:
           pip install --upgrade black[jupyter] flake8 nbqa
           make lint
       - name : validate-release
-        if: ${{ matrix.task == 'validating-examples' && contains(${{env.REF}}, 'refs/heads/release')}}
+        if: ${{ matrix.task == 'validating-examples' && contains(env.REF, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
           echo env.REF
           python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch $(echo ${{env.REF}} | cut -d- -f2)
       - name : validate
-        if: ${{ matrix.task == 'validating-examples' && !contains(${{env.REF}}, 'refs/heads/release')}}
+        if: ${{ matrix.task == 'validating-examples' && !contains(env.REF, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: ${{ github.ref_name }}
+      REF: release-2021.10.26 # ${{ github.base_ref || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -45,4 +45,5 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
+          echo env.REF
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -34,14 +34,14 @@ jobs:
           pip install --upgrade black[jupyter] flake8 nbqa
           make lint
       - name : validate-release
-        if: matrix.task == 'validating-examples' && ${{contains($REF, 'refs/heads/release')}}
+        if: matrix.task == 'validating-examples' && ${{contains(env.REF, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
           branch=$(echo ${{github.target_ref}} | cut -d- -f2)
           python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch ${branch}
       - name : validate
-        if: matrix.task == 'validating-examples' && ${{!contains($REF, 'refs/heads/release')}}
+        if: matrix.task == 'validating-examples' && ${{!contains(env.REF, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: ${{ github.base_ref || github.ref }}
+      REF: ${{ github.base_ref || github.ref_name }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,17 +34,18 @@ jobs:
           pip install --upgrade black[jupyter] flake8 nbqa
           make lint
       - name : validate-release
-        if: ${{ matrix.task == 'validating-examples' && contains(env.REF, 'refs/heads/release')}}
-        shell: bash
-        run: |
-          pip install --upgrade requests jsonschema
-          echo env.REF
-          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch $(echo ${{env.REF}} | cut -d- -f2)
-      - name : validate
-        if: ${{ matrix.task == 'validating-examples' && !contains(env.REF, 'refs/heads/release')}}
+        if: ${{ matrix.task == 'validating-examples' && contains(env.REF, 'release')}}
+        env:
+          BRANCH: $(echo ${{env.REF}} | cut -d- -f2)
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
           echo ${{env.REF}}
-          echo ${{github.base_ref}}
+          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch ${{ env.BRANCH }}
+      - name : validate
+        if: ${{ matrix.task == 'validating-examples' && !contains(env.REF, 'release')}}
+        shell: bash
+        run: |
+          pip install --upgrade requests jsonschema
+          echo ${{env.REF}}
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: [[ github.event = 'pull_request' ]] && github.base_ref || github.ref
+      REF: $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -34,14 +34,14 @@ jobs:
           pip install --upgrade black[jupyter] flake8 nbqa
           make lint
       - name : validate-release
-        if: matrix.task == 'validating-examples' && ${{contains(env.REF, 'refs/heads/release')}}
+        if: ${{ matrix.task == 'validating-examples' && contains(${{env.REF}}, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
           echo env.REF
-          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch $(echo env.REF | cut -d- -f2)
+          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch $(echo ${{env.REF}} | cut -d- -f2)
       - name : validate
-        if: matrix.task == 'validating-examples' && ${{!contains(env.REF, 'refs/heads/release')}}
+        if: ${{ matrix.task == 'validating-examples' && !contains(${{env.REF}}, 'refs/heads/release')}}
         shell: bash
         run: |
           pip install --upgrade requests jsonschema

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -38,8 +38,8 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade requests jsonschema
-          branch=$(echo ${{github.target_ref}} | cut -d- -f2)
-          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch ${branch}
+          echo env.REF
+          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch $(echo env.REF | cut -d- -f2)
       - name : validate
         if: matrix.task == 'validating-examples' && ${{!contains(env.REF, 'refs/heads/release')}}
         shell: bash

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -13,7 +13,7 @@ jobs:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
     env:
-      REF: $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
+      REF: ${{ github.base_ref || github.ref }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,5 +47,4 @@ jobs:
           pip install --upgrade requests jsonschema
           echo ${{env.REF}}
           echo ${{github.base_ref}}
-          echo $([[ github.event = 'pull_request' ]] && echo github.base_ref || echo github.ref)
           make validate

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -1,12 +1,19 @@
 name: Continuous Integration
 
-# alwas run CI on new commits to any branch
-on: push
+# always run CI on new commits to any branch
+on:
+  pull_request:
+  push:
+    branches:
+      - "release*"
+      - main
 
 jobs:
   test:
     name: ${{ matrix.task }}
     runs-on: ubuntu-latest
+    env:
+      REF: [[ github.event = 'pull_request' ]] && github.base_ref || github.ref
     strategy:
       fail-fast: false
       matrix:
@@ -24,5 +31,18 @@ jobs:
         if: matrix.task == 'linting'
         shell: bash
         run: |
-          pip install --upgrade black[jupyter] flake8 nbqa requests jsonschema
+          pip install --upgrade black[jupyter] flake8 nbqa
           make lint
+      - name : validate-release
+        if: matrix.task == 'validating-examples' && ${{contains($REF, 'refs/heads/release')}}
+        shell: bash
+        run: |
+          pip install --upgrade requests jsonschema
+          branch=$(echo ${{github.target_ref}} | cut -d- -f2)
+          python .ci/validate-examples.py --examples-dir $(pwd)/examples --recipe-schema-branch ${branch}
+      - name : validate
+        if: matrix.task == 'validating-examples' && ${{!contains($REF, 'refs/heads/release')}}
+        shell: bash
+        run: |
+          pip install --upgrade requests jsonschema
+          make validate

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ validate:
 	python .ci/validate-examples.py --examples-dir $$(pwd)/examples --recipe-schema-branch main
 
 .PHONY: lint
-lint: validate
+lint:
 	black --check --diff .
 	flake8 --count .
 	nbqa flake8 .


### PR DESCRIPTION
Ok it took some trial and error, but this is now ready. Basically for any given PR against release or push to release validate all recipes against the schema branch corresponding to that release. For all other PRs and pushes to main, use the main branch of recipe schemas.