### PR TITLE
fixed the autoshutoff recipe

### DIFF
--- a/examples/autoshutoff-jupyter-kernel/.saturn/saturn.json
+++ b/examples/autoshutoff-jupyter-kernel/.saturn/saturn.json
@@ -1,5 +1,5 @@
 {
-  "name": "example-autoshutoff-jupyter-kernel",
+  "name": "example-autoshutoff",
   "image_uri": "saturncloud/saturn:2021.09.20",
   "description": "POC of using Jupyter kernel information for shutting off a resource",
   "working_directory": "/home/jovyan/git-repos/examples/examples/autoshutoff-jupyter-kernel",
@@ -8,8 +8,7 @@
   },
   "git_repositories": [
     {
-      "url": "git@github.com:saturncloud/autoshutoff.git",
-      "location": "autoshutoff",
+      "url": "git@github.com:saturncloud/examples.git",
       "on_restart": "reclone"
     }
   ],


### PR DESCRIPTION
Fixed several issues with the autoshutoff recipe

* The resource name was too long
* It was pulling the incorrect repository
* it incorrectly hard-coded the location of the folder