### PR TITLE
changed the environment variable name

### DIFF
--- a/examples/autoshutoff-jupyter-kernel/autoshutoff.py
+++ b/examples/autoshutoff-jupyter-kernel/autoshutoff.py
@@ -26,8 +26,8 @@ def get_user_token(base_url, username, admin_token):
 def autoshutoff():
     """Get a list of users, get their tokens, then shutoff their idle Jupyter servers
     with it"""
-    base_url = os.environ["SATURN_APP_URL"]
-    admin_token = os.environ["ADMIN_ACCESS_TOKEN"]
+    base_url = os.environ["scl-url"]
+    admin_token = os.environ["admin-token"]
     users = get_user_list(base_url, admin_token)
     for user in users:
         username = user["username"]


### PR DESCRIPTION
This pr is for autoshut off, where I have changed name of environment variable . The current code is throwing error because of naming of environment variable; since  "Credential names must start and end with a lowercase letter or number, and can only contain lowercase letters, numbers, and dashes." 