### PR TITLE
Updated template resources ordering

### DIFF
--- a/.saturn/templates.json
+++ b/.saturn/templates.json
@@ -16,7 +16,7 @@
       "title": "RStudio",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rstudio.png",
       "weight": 300,
-      "recipe_path": "examples/api/.saturn/saturn.json"
+      "recipe_path": "examples/rstudio/.saturn/saturn.json"
     },
     {
       "title": "Deploy an API",

--- a/.saturn/templates.json
+++ b/.saturn/templates.json
@@ -1,65 +1,64 @@
 {
   "templates": [
     {
-      "title": "Machine Learning with Snowflake",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/snowflake.png",
-      "weight": 60,
-      "recipe_path": "examples/snowflake-ml/.saturn/saturn.json"
+      "title": "Dask",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/dask.png",
+      "weight": 100,
+      "recipe_path": "examples/dask/.saturn/saturn.json"
     },
     {
       "title": "Distributed PyTorch",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/pytorch.png",
-      "weight": 50,
+      "weight": 200,
       "recipe_path": "examples/pytorch/.saturn/saturn.json"
     },
     {
-      "title": "RAPIDS",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rapids.png",
-      "weight": 2,
-      "recipe_path": "examples/rapids/.saturn/saturn.json"
+      "title": "RStudio",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rstudio.png",
+      "weight": 300,
+      "recipe_path": "examples/api/.saturn/saturn.json"
     },
     {
-      "title": "Prefect",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/prefect.png",
-      "weight": 20,
-      "recipe_path": "examples/prefect/.saturn/saturn.json"
+      "title": "Deploy an API",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api.png",
+      "weight": 400,
+      "recipe_path": "examples/api/.saturn/saturn.json"
     },
     {
       "title": "Snowflake",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/snowflake.png",
-      "weight": 10,
+      "weight": 500,
       "recipe_path": "examples/snowflake/.saturn/saturn.json"
     },
     {
-      "title": "TensorFlow",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/tensorflow.png",
-      "weight": 70,
-      "recipe_path": "examples/tensorflow/.saturn/saturn.json"
-    },
-    {
-      "title": "Dask",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/dask.png",
-      "weight": 30,
-      "recipe_path": "examples/dask/.saturn/saturn.json"
-    },
-   {
       "title": "Deploy Dashboards",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/dashboard.png",
-      "weight": 3,
+      "weight": 600,
       "recipe_path": "examples/dashboard/.saturn/saturn.json"
     },
     {
       "title": "Run a job",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/jobs.png",
-      "weight": 31,
+      "weight": 700,
       "recipe_path": "examples/example-job/.saturn/saturn.json"
-    }
-    ,
-   {
-      "title": "Deploy API",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api.png",
-      "weight": 32,
-      "recipe_path": "examples/api/.saturn/saturn.json"
+    },
+    {
+      "title": "TensorFlow",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/tensorflow.png",
+      "weight": 800,
+      "recipe_path": "examples/tensorflow/.saturn/saturn.json"
+    },
+    {
+      "title": "RAPIDS",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rapids.png",
+      "weight": 900,
+      "recipe_path": "examples/rapids/.saturn/saturn.json"
+    },
+    {
+      "title": "Prefect",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/prefect.png",
+      "weight": 1000,
+      "recipe_path": "examples/prefect/.saturn/saturn.json"
     }
   ]
 }

--- a/examples/rstudio/.saturn/saturn.json
+++ b/examples/rstudio/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
     "name": "example-rstudio",
-    "image_uri": "saturncloud/saturn-rstudio:2021.10.26",
+    "image_uri": "saturncloud/saturn-rstudio:2021.11.10",
     "description": "Use R from RStudio",
     "working_directory": "/home/jovyan/git-repos/examples/examples/rstudio",
     "git_repositories": [


### PR DESCRIPTION
This PR does three things:

* Changes what template resources are included:
  * Adds RStudio since that wasn't available until this release
  * Removes Snowflake ML since we now direct people to use the recipe directly via a button
* Reorders the templates in the UI by changing the weights (the JSON file is also reordered)
* Updates the RStudio recipe to use the latest image (so that the template resource works)