### PR TITLE
Added the RAPIDS comparison

### DIFF
--- a/examples/rapids-comparison/.saturn/README.md
+++ b/examples/rapids-comparison/.saturn/README.md
@@ -1,0 +1,6 @@
+# Zero to RAPIDS in Minutes with NVIDIA GPUs + Saturn Cloud
+
+This example contains the supporting material for the [corresponding blog post](https://developer.nvidia.com/blog/zero-to-rapids-in-minutes-with-nvidia-gpus-saturn-cloud/)
+on the [NVIDIA Developer Blog](https://developer.nvidia.com/).
+
+All of the material is contained in a [single Jupyter notebook](./comparison.ipynb).

--- a/examples/rapids-comparison/.saturn/saturn.json
+++ b/examples/rapids-comparison/.saturn/saturn.json
@@ -1,7 +1,7 @@
 {
-  "name": "example-rapids",
+  "name": "example-rapids-comparison",
   "image_uri": "saturncloud/saturn-rapids:2021.09.20",
-  "description": "Use GPUs for data science and machine learning with this platform by NVIDIA",
+  "description": "Compare how RAPIDS performs at model training with a GPU",
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"
   },

--- a/examples/rapids-comparison/.saturn/saturn.json
+++ b/examples/rapids-comparison/.saturn/saturn.json
@@ -1,0 +1,27 @@
+{
+  "name": "example-rapids",
+  "image_uri": "saturncloud/saturn-rapids:2021.09.20",
+  "description": "Use GPUs for data science and machine learning with this platform by NVIDIA",
+  "environment_variables": {
+    "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"
+  },
+  "working_directory": "/home/jovyan/git-repos/examples/examples/rapids",
+  "git_repositories": [
+    {
+      "url": "https://github.com/saturncloud/examples"
+    }
+  ],
+  "jupyter_server": {
+    "disk_space": "10Gi",
+    "instance_type": "g4dnxlarge"
+  },
+  "dask_cluster": {
+    "num_workers": 3,
+    "worker": {
+      "instance_type": "g4dnxlarge"
+    },
+    "scheduler": {
+      "instance_type": "large"
+    }
+  }
+}

--- a/examples/rapids-comparison/README.md
+++ b/examples/rapids-comparison/README.md
@@ -1,0 +1,6 @@
+# Zero to RAPIDS in Minutes with NVIDIA GPUs + Saturn Cloud
+
+This example contains the supporting material for the [corresponding blog post](https://developer.nvidia.com/blog/zero-to-rapids-in-minutes-with-nvidia-gpus-saturn-cloud/)
+on the [NVIDIA Developer Blog](https://developer.nvidia.com/).
+
+All of the material is contained in a [single Jupyter notebook](./comparison.ipynb).

--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "796a8260",
    "metadata": {
     "execution": {
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "adc933bc",
    "metadata": {
     "execution": {
@@ -62,17 +62,7 @@
      "shell.execute_reply.started": "2021-12-10T19:00:12.815232Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
-      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
-      "100  655M  100  655M    0     0  19.4M      0  0:00:33  0:00:33 --:--:-- 39.3M\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv > data.csv"
    ]
@@ -89,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c26e082a",
    "metadata": {
     "execution": {
@@ -100,16 +90,7 @@
      "shell.execute_reply.started": "2021-12-10T19:01:03.829167Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU: CSV Load: 13 seconds\n",
-      "CPU: Random Forest: 337 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "from sklearn.ensemble import RandomForestClassifier as RFCPU\n",
@@ -141,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2309bc41",
    "metadata": {
     "execution": {
@@ -152,16 +133,7 @@
      "shell.execute_reply.started": "2021-12-10T19:10:10.880233Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GPU: CSV Load: 3 seconds\n",
-      "GPU: Random Forest: 23 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import cudf\n",
     "from cuml.ensemble import RandomForestClassifier as RFGPU\n",
@@ -193,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "7b8874d3",
    "metadata": {
     "execution": {
@@ -216,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "a444b381",
    "metadata": {
     "execution": {
@@ -227,20 +199,7 @@
      "shell.execute_reply.started": "2021-12-10T19:11:45.759812Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAEhCAYAAABmy/ttAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAVZklEQVR4nO3de7TdZX3n8feHJBAQECWniKaazIiGm9yOSEsGUsULQ71gnVEMFi/L2KWC1g5CB+qtQ5fjMMqsSjtmWi9VQApFR9BaoQIJGh0SCJZwKaAo0SAHFAhiIKHf+WPvxMPhJDk5e+ecPMn7tdZZZ/+e37N/v+8+a+eTZz/7d0lVIUlqz06TXYAkaXwMcElqlAEuSY0ywCWpUQa4JDXKAJekRhng0gRK8pEkX5rsOrR9MMC1TUvy5iRLkzySZFWSf0wyt7turySfTXJvktVJ/jXJGd11tyV5+yjbe1+SpRvZ191Jjtu6r0jqHwNc26wkHwDOA/4C2Ad4LvBXwGu7XT4F7A7sDzwdeA1wV3fdF4A/HGWzb+muk5pngGublOTpwMeA91TVZVX1q6paW1WXV9Xp3W4vBi6sql9W1b9V1W1VdWl33ReBuUmeN2yb+wMvAi7awlp2SXJekp91f85Lskt33TOSXJFkKMkvu49nDnvu7CTXdj8hXAnMGPcfRRrBANe26neA6cBXNtHne8A5Sd6WZL/hK6pqJXA1nRH3en8IfKOq7t/CWs4CjgIOBQ4BjgTO7q7bCfgc8Dw6nxB+DXx62HMvBJbRCe4/B07Zwn1LG2WAa1u1N3B/Va3bRJ9TgQuA9wK3JLkzyfHD1n+BboAn2QmYz/imT+YDH6uq+6pqCPjo+u1W1QNV9Q9V9WhVrQbOAY7t7vO5dD4l/FlVPVZVi4DLx7F/aVQGuLZVDwAzkkzdWIeq+nVV/UVVHUEn8P8euCTJM7tdLgP2TXIUMA/YDfj6OGp5NvDjYcs/7raRZLckn0ny4yQPA4uAvZJM6fb5ZVX9asRzpb4wwLWtWgKsAV43ls5V9TCdLzufBszutj0KXEpn6uQtwJer6vFx1PIzOlMk6z232wbwJ8ALgZdU1Z7AMd32AKuAZyR52ojnSn1hgGubVFUPAR8Czk/yuu5Id1qS45N8AiDJnyV5cZKdk0wH3gc8CNw+bFNfAN4I/AFjmz6ZlmT6sJ+pdL70PDvJQJIZ3brWH8u9B5157we7I/8PD3sNPwaWAh/t1jgXePV4/ybSSBv9eCpNtqr6ZJKf0/nC8AJgNZ0vBM9Z34XOF4jPBdYBPwBOqKpHhm1mEfAQ8FhVXT+G3X5jxPI5wH8D9uxuH+CSbht0DnO8ELifzqj8f/LkTw1vpvMfxy/ofKr4O2CvMdQhbVa8oYMktckpFElqlAEuSY0ywCWpUQa4JDVqQo9CmTFjRs2aNWsidylJzVu2bNn9VTUwsn1CA3zWrFksXTrqlTwlSRuRZNQzeJ1CkaRGGeCS1CgDXJIa5an0kraKtWvXsnLlStasWTPZpTRj+vTpzJw5k2nTpo2pvwEuaatYuXIle+yxB7NmzSLJZJezzasqHnjgAVauXMns2bPH9BynUCRtFWvWrGHvvfc2vMcoCXvvvfcWfWIxwCVtNYb3ltnSv5cBLkmNcg5c0oSYdeZ47ma3cXd//IQx9TvnnHO48MILmTJlCjvttBOf+cxneMlLXtLXWjblmmuu4dxzz+WKK67o+7YN8FH0+422oxvrPzSp35YsWcIVV1zBDTfcwC677ML999/P44+P56562yanUCRtt1atWsWMGTPYZZddAJgxYwbPfvazWbZsGcceeyxHHHEEr3zlK1m1ahUAd955J8cddxyHHHIIhx9+OHfddRdVxemnn85BBx3EwQcfzMUXXwx0Rtbz5s3jDW94A3PmzGH+/Pmsv0HON7/5TebMmcPcuXO57LLLNtRz7bXXcuihh3LooYdy2GGHsXr16p5enwEuabv1ile8gnvuuYcXvOAFvPvd7+baa69l7dq1nHrqqVx66aUsW7aMt7/97Zx11lkAzJ8/n/e85z3cdNNNfPe732XfffflsssuY/ny5dx0001cddVVnH766RsC/8Ybb+S8887jlltu4Yc//CHf+c53WLNmDe985zu5/PLLWbx4Mffee++Ges4991zOP/98li9fzuLFi9l11117en1OoUjabu2+++4sW7aMxYsXc/XVV/PGN76Rs88+m5tvvpmXv/zlADzxxBPsu+++rF69mp/+9KeceOKJQOekGoDrrruOk046iSlTprDPPvtw7LHHcv3117Pnnnty5JFHMnPmTAAOPfRQ7r77bnbffXdmz57NfvvtB8DJJ5/MwoULATj66KP5wAc+wPz583n961+/4bnjZYBL2q5NmTKFefPmMW/ePA4++GDOP/98DjzwQJYsWfKkfg8//PCoz9/UfYPXT82s38+6deuAjR8OeOaZZ3LCCSfwjW98g6OOOoqrrrqKOXPmbOlL2sApFEnbrdtvv5077rhjw/Ly5cvZf//9GRoa2hDga9euZcWKFey5557MnDmTr371qwA89thjPProoxxzzDFcfPHFPPHEEwwNDbFo0SKOPPLIje5zzpw5/OhHP+Kuu+4C4KKLLtqw7q677uLggw/mjDPOYHBwkNtuu62n1+cIXNKEmIyjkR555BFOPfVUHnzwQaZOncrzn/98Fi5cyIIFCzjttNN46KGHWLduHe9///s58MAD+eIXv8i73vUuPvShDzFt2jQuueQSTjzxRJYsWcIhhxxCEj7xiU/wrGc9a6PhO336dBYuXMgJJ5zAjBkzmDt3LjfffDMA5513HldffTVTpkzhgAMO4Pjjj+/p9WVTHw/6bXBwsFq4oYOHEfaXhxHumG699Vb233//yS6jOaP93ZIsq6rBkX2dQpGkRhngktQoA1zSVjORU7Tbgy39exngkraK6dOn88ADDxjiY7T+euDrjz8fC49CkbRVzJw5k5UrVzI0NDTZpTRj/R15xsoAl7RVTJs2bcx3ltH4OIUiSY0ywCWpUZsN8CSfTXJfkpuHtf2PJLcl+UGSryTZa6tWKUl6irGMwD8PvGpE25XAQVX1IuBfgT/tc12SpM3YbIBX1SLgFyPavlVV67qL3wN6uyaiJGmL9WMO/O3AP25sZZIFSZYmWerhRJLUPz0FeJKzgHXABRvrU1ULq2qwqgYHBgZ62Z0kaZhxHwee5BTg94GXladaSdKEG1eAJ3kVcAZwbFU92t+SJEljMZbDCC8ClgAvTLIyyTuATwN7AFcmWZ7kf2/lOiVJI2x2BF5VJ43S/LdboRZJ0hbwTExJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktSozQZ4ks8muS/JzcPanpnkyiR3dH8/Y+uWKUkaaSwj8M8DrxrRdibwz1W1H/DP3WVJ0gTabIBX1SLgFyOaXwt8ofv4C8Dr+luWJGlzxjsHvk9VrQLo/v6tjXVMsiDJ0iRLh4aGxrk7SdJIW/1LzKpaWFWDVTU4MDCwtXcnSTuM8Qb4z5PsC9D9fV//SpIkjcV4A/xrwCndx6cA/7c/5UiSxmoshxFeBCwBXphkZZJ3AB8HXp7kDuDl3WVJ0gSaurkOVXXSRla9rM+1SJK2gGdiSlKjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRvUU4En+OMmKJDcnuSjJ9H4VJknatHEHeJLnAKcBg1V1EDAFeFO/CpMkbVqvUyhTgV2TTAV2A37We0mSpLEYd4BX1U+Bc4GfAKuAh6rqWyP7JVmQZGmSpUNDQ+OvVJL0JL1MoTwDeC0wG3g28LQkJ4/sV1ULq2qwqgYHBgbGX6kk6Ul6mUI5DvhRVQ1V1VrgMuB3+1OWJGlzegnwnwBHJdktSYCXAbf2pyxJ0ub0Mgf+feBS4AbgX7rbWtinuiRJmzG1lydX1YeBD/epFknSFvBMTElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIa1VOAJ9kryaVJbktya5Lf6VdhkqRNm9rj8/8X8M2qekOSnYHd+lCTJGkMxh3gSfYEjgHeClBVjwOP96csSdLm9DKF8u+AIeBzSW5M8jdJnjayU5IFSZYmWTo0NNTD7iRJw/US4FOBw4G/rqrDgF8BZ47sVFULq2qwqgYHBgZ62J0kabheAnwlsLKqvt9dvpROoEuSJsC4A7yq7gXuSfLCbtPLgFv6UpUkabN6PQrlVOCC7hEoPwTe1ntJkqSx6CnAq2o5MNifUiRJW8IzMSWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqN6DvAkU5LcmOSKfhQkSRqbfozA3wfc2oftSJK2QE8BnmQmcALwN/0pR5I0Vr2OwM8DPgj828Y6JFmQZGmSpUNDQz3uTpK03rgDPMnvA/dV1bJN9auqhVU1WFWDAwMD492dJGmEXkbgRwOvSXI38GXgpUm+1JeqJEmbNe4Ar6o/raqZVTULeBPw7ao6uW+VSZI2yePAJalRU/uxkaq6BrimH9uSJI2NI3BJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSo/pyIo+kiTHrzK9Pdgnblbs/fsJkl9ATR+CS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNGneAJ/ntJFcnuTXJiiTv62dhkqRN6+VysuuAP6mqG5LsASxLcmVV3dKn2iRJmzDuEXhVraqqG7qPVwO3As/pV2GSpE3ryxx4klnAYcD3R1m3IMnSJEuHhob6sTtJEn0I8CS7A/8AvL+qHh65vqoWVtVgVQ0ODAz0ujtJUldPAZ5kGp3wvqCqLutPSZKksejlKJQAfwvcWlWf7F9JkqSx6GUEfjTwFuClSZZ3f/5jn+qSJG3GuA8jrKrrgPSxFknSFvBMTElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIa1VOAJ3lVktuT3JnkzH4VJUnavHEHeJIpwPnA8cABwElJDuhXYZKkTetlBH4kcGdV/bCqHge+DLy2P2VJkjZnag/PfQ5wz7DllcBLRnZKsgBY0F18JMntPexTTzYDuH+yi9ic/PfJrkCTwPdmfz1vtMZeAjyjtNVTGqoWAgt72I82IsnSqhqc7DqkkXxvToxeplBWAr89bHkm8LPeypEkjVUvAX49sF+S2Ul2Bt4EfK0/ZUmSNmfcUyhVtS7Je4F/AqYAn62qFX2rTGPh1JS2Vb43J0CqnjJtLUlqgGdiSlKjDHBJapQBLkmNMsAlqVG9nMijCZLk9SOais5ZbsuravUklCRtkOTwEU0F3F9V94zWX/3jUSgNSPK5UZqfCbwIeEdVfXuCS5I2SHL1KM3PBHYGTqqq5RNb0Y7DAG9YkucBf19VT7kGjTTZkgwCn6yqYya7lu2Vc+ANq6ofA9Mmuw5pNFW1FNh9suvYnhngDUvyQuCxya5DGk2SfRjlAnfqH7/EbECSy3nqP4RnAvsCJ098RdJvJPlLRn9//i7wvomvaMfhHHgDkhw7oqmAB4A7ujfTkCZNklNGNK1/f15fVfdNQkk7DAO8EUleBzwf+Jeq+qdJLkd6kiSHAf8eWFFVt052PTsK58AbkOSvgD8G9gb+PMmfTXJJ0gbd9+PFwB8AX0/yzkkuaYfhCLwBSW4GDqmqJ5LsBiyuqiMmuy4JIMkK4MVV9WiSvYFvVtWLJ7uuHYEj8DY8XlVPAFTVo4x+Oztpsqzpvi+pqgcwVyaMI/AGJHkUuHP9Ip25xvXLVNWLJqMuCSDJg8Ci9YvAf+guB6iqes0klbbdM8AbkGQ/YB9g5LUlngf8rKrufOqzpIkxylFS8JvDClNV105kPTsSjwNvw6eA/9o983KDJAPdda+elKqkjr2AmVV1PkCS/wcM0AnxMyaxru2ec1VtmFVVPxjZ2D1VedbElyM9yQd58g3NdwYGgXnAH01GQTsKR+BtmL6JdbtOWBXS6HYecenY67pfZj6Q5GmTVdSOwBF4G64f7djaJO8Alk1CPdJwzxi+UFXvHbY4MMG17FD8ErMB3YsCfQV4nN8E9iCdj6onVtW9k1WblOQC4Jqq+j8j2t8FzKuqkyansu2fAd6QJL8HHNRdXOGNHLQtSPJbwFfpXBnzhm7zEcAuwOuq6ueTVNp2zwCX1BdJXgoc2F10gDEBDHBJapRfYkpSowxwSWqUAa5mJHlkxPJbk3y6x23enWRGb5VJk8MA1w4jyVY/cS3JlK29D2k9A1zbhSSvTvL9JDcmuap77DxJPpJkYZJvAX+XZO8k3+r2+wzdS/Mm+WCS07qPP5Xk293HL0vype7jv06yNMmKJB8dtu+7k3woyXXAf0ryiiRLktyQ5JIk3pldW4UBrpbsmmT5+h/gY8PWXQccVVWHAV+mc32O9Y4AXltVbwY+TOdU78PoXL/jud0+i+hcBhU6J0ntnmQaMBdY3G0/q6oGgRcBxyYZfhnfNVU1F7gKOBs4rqoOB5YCH+jDa5eewmuhqCW/rqpD1y8keSudsAWYCVycZF86Z6j+aNjzvlZVv+4+PgZ4PUBVfT3JL7vty4AjkuzBb05IGaQT6qd1+/znJAvo/LvZFzgAWH+RsYu7v4/qtn8nCd1alvT0qqWNMMC1vfhL4JNV9bUk84CPDFv3qxF9n3LyQ1WtTXI38Dbgu3SC+ffo3Dzj1iSzgf9C59Zhv0zyeZ58kbH1+whwpaePayI4haLtxdOBn3Yfn7KJfouA+QBJjufJF2JaRCekF9GZNvkjYHl1znbbk05IP9SdXz9+I9v/HnB0kud397FbkheM6xVJm2GAa3vxEeCSJIuB+zfR76PAMUluAF4B/GTYusV0pkaWdK/fsabbRlXdBNwIrAA+C3xntI1X1RDwVuCiJD+gE+hzxv2qpE3wVHpJapQjcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGvX/AahWksNN+UCGAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df[df.task == \"CSV Load\"].plot(\n",
     "    title=\"CSV Load\",\n",
@@ -252,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "e1acfec9",
    "metadata": {
     "execution": {
@@ -263,20 +222,7 @@
      "shell.execute_reply.started": "2021-12-10T19:11:48.309262Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEhCAYAAACEF+AUAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAaxklEQVR4nO3df5BU5Z3v8ffHEcENulEZycgQ4UZcBImDTtC7ukri73UN4sYEglmyscStoMabXCOabKK7RZWbIupWrloZr17JDxU0RvFHTMCogLLqoKPhh6wgKCMII5EIGhDG7/2jz2A79Mz0/OzMM59XVVef85zn9Pn21PDhzNPnPK2IwMzM0rJPqQswM7Ou53A3M0uQw93MLEEOdzOzBDnczcwS5HA3M0uQw92SJelaSb8odR1mpeBwtx4laZ2kP0vaLuktSXdKGljqujpD0nhJH2bvqenxUA8ef5ikkLRvTx3T/vI53K0Uzo2IgUAVMBa4urTldIkNETEw73Fue19AUll3FGZ9k8PdSiYi3gJ+Sy7kAZA0Q9IaSdskrZA0MW/b1yUtljRL0juS1ko6O2/7cElPZfvOBwblH0/SFyUtl7RV0pOSjsrbtk7SlZJelvSepNslDZb0m+z1Fkg6qL3vUdJR2bG2Zsf+Yt62OyXdKulRSe8Bn5d0mKRfSWrI3t/lef3HSaqV9K6kTZJuyDYtzJ63Zn81/M/21mnpcbhbyUiqBM4GVuc1rwH+Dvhr4DrgF5Iq8rYfD6wiF9w/Am6XpGzbXcDSbNu/A1PzjnUkcDdwBVAOPAo8JGm/vNf+R+B04EjgXOA3wDXZ6+0DXE47SOoHPAT8DjgUuAz4paS/yev2VWAmcADwTNb/JWAIcCpwhaQzs77/CfxnRBwIfAaYm7WfnD1/MvurYUl76rQ0OdytFB6QtA1YD2wGfti0ISLujYgNEfFhRMwBXgXG5e37ekTcFhGNwGygAhgs6dPA54B/jYidEbGQXFA2+QrwSETMj4hdwCxgf+Bv8/r8JCI2RcSbwCLg2Yh4MSJ2Ar8mN4TUksOys/Omx5eBE4CBwPUR8UFE/B54GJict9+DEfF0RHwIjAHKI+Lfsv6vAbcBk7K+u4AjJA2KiO0R8V+t/pStT3O4WymcFxEHAOOBkeQNn0j6J0l1TSEJHM3Hh1fealqIiPezxYHAYcA7EfFeXt/X85YPy1/PwnQ9uTPkJpvylv9cYL21D343RMQn8x5zs2Ouz46VX1P+MdfnLR9Os/8kyP3lMDjbfhG5vypekfS8pH9opR7r4/zpupVMRDwl6U5yZ9HnSTqc3JnqqcCSiGiUVAeo5VfZYyNwkKRP5AX8p4GmaU83kDszBiAbyhkKvNkV76UFG4ChkvbJC/hPA/+d1yd/Wtb1wNqIGFHoxSLiVWCypH2A84H7JB3S7DXMAJ+5W+ndBJwuqQr4BLmgagCQ9M/kztzbFBGvA7XAdZL2k3QSuXHzJnOBcySdmo2FfwfYSW6cu7s8C7wHfFdSP0njs5ruaaH/c8C7kq6StL+kMklHS/ocgKQLJZVn/1FszfZpJPfz+hD4H933Vqy3cbhbSUVEA/AzcmPlK4AfA0vIDYmMAZ5ux8t9ldwHrn8kN47/s7zjrAIuBH4CvE0uZM+NiA+64G0UlL32F8l9aPw2cAvwTxHxSgv9G7O6qoC12T7/l9yHywBnAcslbSf34eqkiNiRDU/NBJ7OhnNO6K73ZL2H/GUdZmbp8Zm7mVmCHO5mZglyuJuZJcjhbmaWoDavc5c0gNzcFf2z/vdFxA8lXQtcTHbZGnBNRDya7XM1uRsuGoHLI+K3rR1j0KBBMWzYsI6+BzOzPmnp0qVvR0R5oW3F3MS0E/hCRGzPrg9eLOk32bYbI2JWfmdJo8jdLj2a3B16CyQdmV3mVdCwYcOora0t5r2YmVlG0ustbWtzWCZytmer/bJHa9dPTgDuyeb3WEtuUqhxrfQ3M7MuVtSYe3anXB25SZ7mR8Sz2aZLsylS78ibDnUIH58vo56Pz6XR9JrTsulLaxsaGppvNjOzTigq3COiMSKqgEpgnKSjgVvJTTtaRW5ejx9n3QvNA7LXmX5E1EREdURUl5cXHDIyM7MOatfEYRGxVdKTwFn5Y+2SbiM3lSnkztSH5u1WSW4CJTMzdu3aRX19PTt27Ch1Kb3GgAEDqKyspF+/fkXvU8zVMuXArizY9wdOA/5DUkVEbMy6TQSWZcvzgLuyb4k5DBhBbkIkMzPq6+s54IADGDZsGB99z4q1JCLYsmUL9fX1DB8+vOj9ijlzrwBmK/f9jvsAcyPiYUk/z2byC2AdcElWyHJJc4EVwG5gemtXyphZ37Jjxw4HeztI4pBDDqG9n022Ge4R8TIFvoEmIr7Wyj4zyc1SZ2a2Fwd7+3Tk5+U7VM3MEuRvYjKzkho245Eufb11159TVL+ZM2dy1113UVZWxj777MNPf/pTjj/++C6tpTVPPvkks2bN4uGHH267cwc43Nuhq38J+7pi/xGadbUlS5bw8MMP88ILL9C/f3/efvttPvig2763pSQ8LGNmfc7GjRsZNGgQ/fv3B2DQoEEcdthhLF26lFNOOYXjjjuOM888k40bcxcErl69mtNOO41jjjmGY489ljVr1hARXHnllRx99NGMGTOGOXPmALkz8vHjx/OlL32JkSNHMmXKFJq+FOmxxx5j5MiRnHTSSdx///176nnqqaeoqqqiqqqKsWPHsm3btk6/R4e7mfU5Z5xxBuvXr+fII4/km9/8Jk899RS7du3isssu47777mPp0qV84xvf4Hvf+x4AU6ZMYfr06bz00ks888wzVFRUcP/991NXV8dLL73EggULuPLKK/f8Z/Diiy9y0003sWLFCl577TWefvppduzYwcUXX8xDDz3EokWLeOutt/bUM2vWLG6++Wbq6upYtGgR+++/f6ffo4dlzKzPGThwIEuXLmXRokU88cQTfOUrX+H73/8+y5Yt4/TTTwegsbGRiooKtm3bxptvvsnEiROB3A1FAIsXL2by5MmUlZUxePBgTjnlFJ5//nkOPPBAxo0bR2VlJQBVVVWsW7eOgQMHMnz4cEaMGAHAhRdeSE1NDQAnnngi3/72t5kyZQrnn3/+nn07w+FuZn1SWVkZ48ePZ/z48YwZM4abb76Z0aNHs2TJko/1e/fddwvu39r3TzcN9zQdZ/fu3UDLlzTOmDGDc845h0cffZQTTjiBBQsWMHLkyPa+pY/xsIyZ9TmrVq3i1Vdf3bNeV1fHUUcdRUNDw55w37VrF8uXL+fAAw+ksrKSBx54AICdO3fy/vvvc/LJJzNnzhwaGxtpaGhg4cKFjBvX8gS4I0eOZO3ataxZswaAu+++e8+2NWvWMGbMGK666iqqq6t55ZVXOv0efeZuZiVViqumtm/fzmWXXcbWrVvZd999OeKII6ipqWHatGlcfvnl/OlPf2L37t1cccUVjB49mp///Odccskl/OAHP6Bfv37ce++9TJw4kSVLlnDMMccgiR/96Ed86lOfajGYBwwYQE1NDeeccw6DBg3ipJNOYtmy3KwtN910E0888QRlZWWMGjWKs88+u9PvUa39adFTqqurozd8WYcvhexavhSyb1q5ciVHHXVUqcvodQr93CQtjYjqQv09LGNmliCHu5lZghzuZtbj/hKGg3uTjvy8HO5m1qMGDBjAli1bHPBFaprPven6+mL5ahkz61GVlZXU19e3e37yvqzpm5jaw+FuZj2qX79+7fpGIesYD8uYmSXI4W5mliCHu5lZghzuZmYJcribmSWozXCXNEDSc5JekrRc0nVZ+8GS5kt6NXs+KG+fqyWtlrRK0pnd+QbMzGxvxZy57wS+EBHHAFXAWZJOAGYAj0fECODxbB1Jo4BJwGjgLOAWSWXdULuZmbWgzXCPnO3Zar/sEcAEYHbWPhs4L1ueANwTETsjYi2wGmh5kmMzM+tyRY25SyqTVAdsBuZHxLPA4IjYCJA9H5p1HwKsz9u9Pmtr/prTJNVKqvWdamZmXauocI+IxoioAiqBcZKObqV7oe+R2msSiYioiYjqiKguLy8vqlgzMytOu66WiYitwJPkxtI3SaoAyJ43Z93qgaF5u1UCGzpbqJmZFa+Yq2XKJX0yW94fOA14BZgHTM26TQUezJbnAZMk9Zc0HBgBPNfFdZuZWSuKmTisApidXfGyDzA3Ih6WtASYK+ki4A3gAoCIWC5pLrAC2A1Mj4jG7infzMwKaTPcI+JlYGyB9i3AqS3sMxOY2enqzMysQ3yHqplZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJajPcJQ2V9ISklZKWS/pW1n6tpDcl1WWPv8/b52pJqyWtknRmd74BMzPb275F9NkNfCciXpB0ALBU0vxs240RMSu/s6RRwCRgNHAYsEDSkRHR2JWFm5lZy9o8c4+IjRHxQra8DVgJDGlllwnAPRGxMyLWAquBcV1RrJmZFaddY+6ShgFjgWezpkslvSzpDkkHZW1DgPV5u9VT4D8DSdMk1UqqbWhoaH/lZmbWoqLDXdJA4FfAFRHxLnAr8BmgCtgI/Lipa4HdY6+GiJqIqI6I6vLy8vbWbWZmrSgq3CX1Ixfsv4yI+wEiYlNENEbEh8BtfDT0Ug8Mzdu9EtjQdSWbmVlbirlaRsDtwMqIuCGvvSKv20RgWbY8D5gkqb+k4cAI4LmuK9nMzNpSzNUyJwJfA/4gqS5ruwaYLKmK3JDLOuASgIhYLmkusILclTbTfaWMmVnPajPcI2IxhcfRH21ln5nAzE7UZWZmneA7VM3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLUJvhLmmopCckrZS0XNK3svaDJc2X9Gr2fFDePldLWi1plaQzu/MNmJnZ3oo5c98NfCcijgJOAKZLGgXMAB6PiBHA49k62bZJwGjgLOAWSWXdUbyZmRXWZrhHxMaIeCFb3gasBIYAE4DZWbfZwHnZ8gTgnojYGRFrgdXAuC6u28zMWtGuMXdJw4CxwLPA4IjYCLn/AIBDs25DgPV5u9Vnbc1fa5qkWkm1DQ0NHSjdzMxaUnS4SxoI/Aq4IiLeba1rgbbYqyGiJiKqI6K6vLy82DLMzKwIRYW7pH7kgv2XEXF/1rxJUkW2vQLYnLXXA0Pzdq8ENnRNuWZmVoxirpYRcDuwMiJuyNs0D5iaLU8FHsxrnySpv6ThwAjgua4r2czM2rJvEX1OBL4G/EFSXdZ2DXA9MFfSRcAbwAUAEbFc0lxgBbkrbaZHRGNXF25mZi1rM9wjYjGFx9EBTm1hn5nAzE7UZWZmneA7VM3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEtRmuEu6Q9JmScvy2q6V9Kakuuzx93nbrpa0WtIqSWd2V+FmZtayYs7c7wTOKtB+Y0RUZY9HASSNAiYBo7N9bpFU1lXFmplZcdoM94hYCPyxyNebANwTETsjYi2wGhjXifrMzKwDOjPmfqmkl7Nhm4OytiHA+rw+9VmbmZn1oI6G+63AZ4AqYCPw46xdBfpGoReQNE1SraTahoaGDpZhZmaFdCjcI2JTRDRGxIfAbXw09FIPDM3rWglsaOE1aiKiOiKqy8vLO1KGmZm1oEPhLqkib3Ui0HQlzTxgkqT+koYDI4DnOleimZm1175tdZB0NzAeGCSpHvghMF5SFbkhl3XAJQARsVzSXGAFsBuYHhGN3VK5mZm1qM1wj4jJBZpvb6X/TGBmZ4oyM7PO8R2qZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSWozXCXdIekzZKW5bUdLGm+pFez54Pytl0tabWkVZLO7K7CzcysZcWcud8JnNWsbQbweESMAB7P1pE0CpgEjM72uUVSWZdVa2ZmRWkz3CNiIfDHZs0TgNnZ8mzgvLz2eyJiZ0SsBVYD47qmVDMzK1ZHx9wHR8RGgOz50Kx9CLA+r1991rYXSdMk1UqqbWho6GAZZmZWSFd/oKoCbVGoY0TURER1RFSXl5d3cRlmZn1bR8N9k6QKgOx5c9ZeDwzN61cJbOh4eWZm1hEdDfd5wNRseSrwYF77JEn9JQ0HRgDPda5EMzNrr33b6iDpbmA8MEhSPfBD4HpgrqSLgDeACwAiYrmkucAKYDcwPSIau6l2MzNrQZvhHhGTW9h0agv9ZwIzO1OUmZl1ju9QNTNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxB+3ZmZ0nrgG1AI7A7IqolHQzMAYYB64AvR8Q7nSvTzMzaoyvO3D8fEVURUZ2tzwAej4gRwOPZupmZ9aDuGJaZAMzOlmcD53XDMczMrBWdDfcAfidpqaRpWdvgiNgIkD0fWmhHSdMk1UqqbWho6GQZZmaWr1Nj7sCJEbFB0qHAfEmvFLtjRNQANQDV1dXRyTrMzCxPp87cI2JD9rwZ+DUwDtgkqQIge97c2SLNzKx9Ohzukj4h6YCmZeAMYBkwD5iadZsKPNjZIs3MrH06MywzGPi1pKbXuSsiHpP0PDBX0kXAG8AFnS/TzMzao8PhHhGvAccUaN8CnNqZoszMrHN8h6qZWYIc7mZmCXK4m5klyOFuZpYgh7uZWYIc7mZmCXK4m5klyOFuZpYgh7uZWYIc7mZmCXK4m5klqLPzuZvZX4hhMx4pdQnJWHf9OaUuodN85m5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZgrot3CWdJWmVpNWSZnTXcczMbG/dEu6SyoCbgbOBUcBkSaO641hmZra37jpzHwesjojXIuID4B5gQjcdy8zMmumuWSGHAOvz1uuB4/M7SJoGTMtWt0ta1U219EWDgLdLXURb9B+lrsBKwL+bXevwljZ0V7irQFt8bCWiBqjppuP3aZJqI6K61HWYNeffzZ7TXcMy9cDQvPVKYEM3HcvMzJrprnB/Hhghabik/YBJwLxuOpaZmTXTLcMyEbFb0qXAb4Ey4I6IWN4dx7KCPNxlf6n8u9lDFBFt9zIzs17Fd6iamSXI4W5mliCHu5lZghzuZmYJ6q6bmKyHSDq/WVOQuwOwLiK2laAkMwAkHdusKYC3I2J9of7WtXy1TC8n6f8VaD4Y+CxwUUT8vodLMgNA0hMFmg8G9gMmR0Rdz1bUtzjcEyXpcGBuRBzfZmezHiSpGrghIk4udS0p85h7oiLidaBfqesway4iaoGBpa4jdQ73REn6G2Bnqeswa07SYJpNJGhdzx+o9nKSHmLvfygHAxXAhT1fkVmOpJ9Q+Hfzb4Fv9XxFfYvH3Hs5Sac0awpgC/Bq9kUpZiUhaWqzpqbfzecjYnMJSupTHO4JkHQecATwh4j4bYnLMdtD0ljgM8DyiFhZ6nr6Eo+593KSbgH+F3AI8O+S/rXEJZkBkP0uzgH+EXhE0sUlLqlP8Zl7LydpGXBMRDRK+itgUUQcV+q6zCQtBz4XEe9LOgR4LCI+V+q6+gqfufd+H0REI0BEvE/hrzg0K4Ud2e8kEbEF502P8pl7LyfpfWB10yq58c2mdSLis6Woy0zSVmBh0yrwd9m6gIiIL5aotD7B4d7LSRoBDAaaz9dxOLAhIlbvvZdZ9ytwJRd8dGmkIuKpnqynr/F17r3fjcA12R2pe0gqz7adW5KqzOCTQGVE3Awg6TmgnFzAX1XCuvoEj4H1fsMi4uXmjdkt3sN6vhyzPb4LzMtb3w+oBsYD/1KKgvoSn7n3fgNa2bZ/j1Vhtrf9mk3vuzj7YHWLpE+Uqqi+wmfuvd/zha4flnQRsLQE9Zg1OSh/JSIuzVst7+Fa+hx/oNrLZZMw/Rr4gI/CvJrcn8ATI+KtUtVmfZukXwJPRsRtzdovAcZHxOTSVNY3ONwTIenzwNHZ6nJ/SYeVmqRDgQfIzU76QtZ8HNAfOC8iNpWotD7B4W5m3UrSF4DR2apPPHqIw93MLEH+QNXMLEEOdzOzBDncLQmStjdb/7qk/9PJ11wnaVDnKjMrDYe7GSCp22/ok1TW3ccwa+Jwt+RJOlfSs5JelLQguzcASddKqpH0O+Bnkg6R9Lus30/Jpk+W9F1Jl2fLN0r6fbZ8qqRfZMu3SqqVtFzSdXnHXifpB5IWAxdIOkPSEkkvSLpX0sAe/nFYH+Fwt1TsL6mu6QH8W962xcAJETEWuIfcnCdNjgMmRMRXgR+Su0V+LLk5UT6d9VlIbrpayN0gNlBSP+AkYFHW/r2IqAY+C5wiKX+q5R0RcRKwAPg+cFpEHAvUAt/ugvduthfPLWOp+HNEVDWtSPo6uSAGqATmSKogd+fu2rz95kXEn7Plk4HzASLiEUnvZO1LgeMkHcBHN+RUkwv8y7M+X5Y0jdy/qQpgFNA0oduc7PmErP1pSWS1LOnUuzZrgcPd+oKfADdExDxJ44Fr87a916zvXjd+RMQuSeuAfwaeIRfanyf3xSgrJQ0H/je5r5R7R9KdfHxCt6ZjCJjv2+6tJ3hYxvqCvwbezJanttJvITAFQNLZfHziq4XkAnwhuaGYfwHqIncX4IHkAvxP2Xj+2S28/n8BJ0o6IjvGX0k6skPvyKwNDnfrC64F7pW0CHi7lX7XASdLegE4A3gjb9sicsMtS7I5UXZkbUTES8CLwHLgDuDpQi8eEQ3A14G7Jb1MLuxHdvhdmbXC0w+YmSXIZ+5mZglyuJuZJcjhbmaWIIe7mVmCHO5mZglyuJuZJcjhbmaWoP8PpY7uMIQnL/kAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df[df.task == \"Random Forest\"].plot(\n",
     "    title=\"Random Forest\",\n",
@@ -300,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "9fac0659",
    "metadata": {
     "execution": {
@@ -324,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "ae471a70",
    "metadata": {
     "execution": {
@@ -335,15 +281,7 @@
      "shell.execute_reply.started": "2021-12-10T19:16:31.324329Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GPU + Dask: Random Forest: 32 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with timing(\"GPU + Dask: Random Forest (12x the data)\"):\n",
     "    taxi_dask = dask_cudf.read_csv(\n",

--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -1,0 +1,400 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "250fc05f",
+   "metadata": {},
+   "source": [
+    "# Zero to RAPIDS in Minutes\n",
+    "\n",
+    "_Compare CPU (scikit-learn) to GPU (cuML) for training random forest models_\n",
+    "\n",
+    "This example shows the speed difference between using a CPU versus a GPU to train a random forest machine learning model. To test the CPU, the\n",
+    "popular machine learning package scikit-learn is used, while for the GPU the RAPIDS framework from NVIDIA is used. It also compares using a Dask cluster running multiple machines with GPUs for even more power when training.\n",
+    "\n",
+    "For more context of this comparison you can find the details on the [RAPIDS blog post](https://developer.nvidia.com/blog/zero-to-rapids-in-minutes-with-nvidia-gpus-saturn-cloud/).\n",
+    "\n",
+    "## Set up the experiment\n",
+    "\n",
+    "To set up the experiment, the context manager is set up to measure recording timings. In a separate chunk the comparison data is downloaded. It's large csv file of New York taxi data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "796a8260",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:00:10.916163Z",
+     "iopub.status.busy": "2021-12-10T19:00:10.915788Z",
+     "iopub.status.idle": "2021-12-10T19:00:10.923842Z",
+     "shell.execute_reply": "2021-12-10T19:00:10.923324Z",
+     "shell.execute_reply.started": "2021-12-10T19:00:10.916090Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from time import time\n",
+    "from contextlib import contextmanager\n",
+    "\n",
+    "times = []\n",
+    "\n",
+    "\n",
+    "@contextmanager\n",
+    "def timing(description: str) -> None:\n",
+    "    start = time()\n",
+    "    yield\n",
+    "    elapsed = time() - start\n",
+    "    times.append((description, elapsed))\n",
+    "    print(f\"{description}: {round(elapsed)} seconds\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "adc933bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:00:12.815256Z",
+     "iopub.status.busy": "2021-12-10T19:00:12.814950Z",
+     "iopub.status.idle": "2021-12-10T19:00:47.137792Z",
+     "shell.execute_reply": "2021-12-10T19:00:47.137095Z",
+     "shell.execute_reply.started": "2021-12-10T19:00:12.815232Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  655M  100  655M    0     0  19.4M      0  0:00:33  0:00:33 --:--:-- 39.3M\n"
+     ]
+    }
+   ],
+   "source": [
+    "!curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv > data.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52ae594b",
+   "metadata": {},
+   "source": [
+    "## Test the CPU with scikit-learn\n",
+    "\n",
+    "The next chunk computes the time to read the csv in with pandas and then run the scikit-learn random forest model training function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c26e082a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:01:03.829195Z",
+     "iopub.status.busy": "2021-12-10T19:01:03.828866Z",
+     "iopub.status.idle": "2021-12-10T19:06:54.794743Z",
+     "shell.execute_reply": "2021-12-10T19:06:54.794075Z",
+     "shell.execute_reply.started": "2021-12-10T19:01:03.829167Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU: CSV Load: 13 seconds\n",
+      "CPU: Random Forest: 337 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from sklearn.ensemble import RandomForestClassifier as RFCPU\n",
+    "\n",
+    "with timing(\"CPU: CSV Load\"):\n",
+    "    taxi_cpu = pd.read_csv(\n",
+    "        \"data.csv\",\n",
+    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "    )\n",
+    "\n",
+    "X_cpu = taxi_cpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].fillna(-1)\n",
+    "y_cpu = taxi_cpu[\"tip_amount\"] > 1\n",
+    "\n",
+    "rf_cpu = RFCPU(n_estimators=100, n_jobs=-1)\n",
+    "\n",
+    "with timing(\"CPU: Random Forest\"):\n",
+    "    _ = rf_cpu.fit(X_cpu, y_cpu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "443db64d",
+   "metadata": {},
+   "source": [
+    "## Test the GPU with RAPIDS\n",
+    "\n",
+    "This section uses the `cudf` and `cuml` packages, part of RAPIDS, which perform their loading and model fitting computations using the GPU. You'll notice this runs far faster than the CPU training, while having similar syntax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2309bc41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:10:10.880259Z",
+     "iopub.status.busy": "2021-12-10T19:10:10.879952Z",
+     "iopub.status.idle": "2021-12-10T19:10:38.072478Z",
+     "shell.execute_reply": "2021-12-10T19:10:38.071641Z",
+     "shell.execute_reply.started": "2021-12-10T19:10:10.880233Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GPU: CSV Load: 3 seconds\n",
+      "GPU: Random Forest: 23 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cudf\n",
+    "from cuml.ensemble import RandomForestClassifier as RFGPU\n",
+    "\n",
+    "with timing(\"GPU: CSV Load\"):\n",
+    "    taxi_gpu = cudf.read_csv(\n",
+    "        \"data.csv\",\n",
+    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "    )\n",
+    "\n",
+    "X_gpu = taxi_gpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].astype(\"float32\").fillna(-1)\n",
+    "y_gpu = (taxi_gpu[\"tip_amount\"] > 1).astype(\"int32\")\n",
+    "\n",
+    "rf_gpu = RFGPU(n_estimators=100)\n",
+    "\n",
+    "with timing(\"GPU: Random Forest\"):\n",
+    "    _ = rf_gpu.fit(X_gpu, y_gpu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74751376",
+   "metadata": {},
+   "source": [
+    "## Comparing results results\n",
+    "\n",
+    "Finally, we compare the results visually using matplotlib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7b8874d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:11:45.222625Z",
+     "iopub.status.busy": "2021-12-10T19:11:45.222326Z",
+     "iopub.status.idle": "2021-12-10T19:11:45.272464Z",
+     "shell.execute_reply": "2021-12-10T19:11:45.271926Z",
+     "shell.execute_reply.started": "2021-12-10T19:11:45.222599Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib as mpl\n",
+    "\n",
+    "mpl.rcParams[\"figure.dpi\"] = 300\n",
+    "\n",
+    "df = pd.DataFrame(times, columns=[\"description\", \"Seconds\"])\n",
+    "df[[\"Hardware\", \"task\"]] = df.description.str.split(\": \", 1, expand=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a444b381",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:11:45.759835Z",
+     "iopub.status.busy": "2021-12-10T19:11:45.759562Z",
+     "iopub.status.idle": "2021-12-10T19:11:46.438641Z",
+     "shell.execute_reply": "2021-12-10T19:11:46.438046Z",
+     "shell.execute_reply.started": "2021-12-10T19:11:45.759812Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAEhCAYAAABmy/ttAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAVZklEQVR4nO3de7TdZX3n8feHJBAQECWniKaazIiGm9yOSEsGUsULQ71gnVEMFi/L2KWC1g5CB+qtQ5fjMMqsSjtmWi9VQApFR9BaoQIJGh0SCJZwKaAo0SAHFAhiIKHf+WPvxMPhJDk5e+ecPMn7tdZZZ/+e37N/v+8+a+eTZz/7d0lVIUlqz06TXYAkaXwMcElqlAEuSY0ywCWpUQa4JDXKAJekRhng0gRK8pEkX5rsOrR9MMC1TUvy5iRLkzySZFWSf0wyt7turySfTXJvktVJ/jXJGd11tyV5+yjbe1+SpRvZ191Jjtu6r0jqHwNc26wkHwDOA/4C2Ad4LvBXwGu7XT4F7A7sDzwdeA1wV3fdF4A/HGWzb+muk5pngGublOTpwMeA91TVZVX1q6paW1WXV9Xp3W4vBi6sql9W1b9V1W1VdWl33ReBuUmeN2yb+wMvAi7awlp2SXJekp91f85Lskt33TOSXJFkKMkvu49nDnvu7CTXdj8hXAnMGPcfRRrBANe26neA6cBXNtHne8A5Sd6WZL/hK6pqJXA1nRH3en8IfKOq7t/CWs4CjgIOBQ4BjgTO7q7bCfgc8Dw6nxB+DXx62HMvBJbRCe4/B07Zwn1LG2WAa1u1N3B/Va3bRJ9TgQuA9wK3JLkzyfHD1n+BboAn2QmYz/imT+YDH6uq+6pqCPjo+u1W1QNV9Q9V9WhVrQbOAY7t7vO5dD4l/FlVPVZVi4DLx7F/aVQGuLZVDwAzkkzdWIeq+nVV/UVVHUEn8P8euCTJM7tdLgP2TXIUMA/YDfj6OGp5NvDjYcs/7raRZLckn0ny4yQPA4uAvZJM6fb5ZVX9asRzpb4wwLWtWgKsAV43ls5V9TCdLzufBszutj0KXEpn6uQtwJer6vFx1PIzOlMk6z232wbwJ8ALgZdU1Z7AMd32AKuAZyR52ojnSn1hgGubVFUPAR8Czk/yuu5Id1qS45N8AiDJnyV5cZKdk0wH3gc8CNw+bFNfAN4I/AFjmz6ZlmT6sJ+pdL70PDvJQJIZ3brWH8u9B5157we7I/8PD3sNPwaWAh/t1jgXePV4/ybSSBv9eCpNtqr6ZJKf0/nC8AJgNZ0vBM9Z34XOF4jPBdYBPwBOqKpHhm1mEfAQ8FhVXT+G3X5jxPI5wH8D9uxuH+CSbht0DnO8ELifzqj8f/LkTw1vpvMfxy/ofKr4O2CvMdQhbVa8oYMktckpFElqlAEuSY0ywCWpUQa4JDVqQo9CmTFjRs2aNWsidylJzVu2bNn9VTUwsn1CA3zWrFksXTrqlTwlSRuRZNQzeJ1CkaRGGeCS1CgDXJIa5an0kraKtWvXsnLlStasWTPZpTRj+vTpzJw5k2nTpo2pvwEuaatYuXIle+yxB7NmzSLJZJezzasqHnjgAVauXMns2bPH9BynUCRtFWvWrGHvvfc2vMcoCXvvvfcWfWIxwCVtNYb3ltnSv5cBLkmNcg5c0oSYdeZ47ma3cXd//IQx9TvnnHO48MILmTJlCjvttBOf+cxneMlLXtLXWjblmmuu4dxzz+WKK67o+7YN8FH0+422oxvrPzSp35YsWcIVV1zBDTfcwC677ML999/P44+P56562yanUCRtt1atWsWMGTPYZZddAJgxYwbPfvazWbZsGcceeyxHHHEEr3zlK1m1ahUAd955J8cddxyHHHIIhx9+OHfddRdVxemnn85BBx3EwQcfzMUXXwx0Rtbz5s3jDW94A3PmzGH+/Pmsv0HON7/5TebMmcPcuXO57LLLNtRz7bXXcuihh3LooYdy2GGHsXr16p5enwEuabv1ile8gnvuuYcXvOAFvPvd7+baa69l7dq1nHrqqVx66aUsW7aMt7/97Zx11lkAzJ8/n/e85z3cdNNNfPe732XfffflsssuY/ny5dx0001cddVVnH766RsC/8Ybb+S8887jlltu4Yc//CHf+c53WLNmDe985zu5/PLLWbx4Mffee++Ges4991zOP/98li9fzuLFi9l11117en1OoUjabu2+++4sW7aMxYsXc/XVV/PGN76Rs88+m5tvvpmXv/zlADzxxBPsu+++rF69mp/+9KeceOKJQOekGoDrrruOk046iSlTprDPPvtw7LHHcv3117Pnnnty5JFHMnPmTAAOPfRQ7r77bnbffXdmz57NfvvtB8DJJ5/MwoULATj66KP5wAc+wPz583n961+/4bnjZYBL2q5NmTKFefPmMW/ePA4++GDOP/98DjzwQJYsWfKkfg8//PCoz9/UfYPXT82s38+6deuAjR8OeOaZZ3LCCSfwjW98g6OOOoqrrrqKOXPmbOlL2sApFEnbrdtvv5077rhjw/Ly5cvZf//9GRoa2hDga9euZcWKFey5557MnDmTr371qwA89thjPProoxxzzDFcfPHFPPHEEwwNDbFo0SKOPPLIje5zzpw5/OhHP+Kuu+4C4KKLLtqw7q677uLggw/mjDPOYHBwkNtuu62n1+cIXNKEmIyjkR555BFOPfVUHnzwQaZOncrzn/98Fi5cyIIFCzjttNN46KGHWLduHe9///s58MAD+eIXv8i73vUuPvShDzFt2jQuueQSTjzxRJYsWcIhhxxCEj7xiU/wrGc9a6PhO336dBYuXMgJJ5zAjBkzmDt3LjfffDMA5513HldffTVTpkzhgAMO4Pjjj+/p9WVTHw/6bXBwsFq4oYOHEfaXhxHumG699Vb233//yS6jOaP93ZIsq6rBkX2dQpGkRhngktQoA1zSVjORU7Tbgy39exngkraK6dOn88ADDxjiY7T+euDrjz8fC49CkbRVzJw5k5UrVzI0NDTZpTRj/R15xsoAl7RVTJs2bcx3ltH4OIUiSY0ywCWpUZsN8CSfTXJfkpuHtf2PJLcl+UGSryTZa6tWKUl6irGMwD8PvGpE25XAQVX1IuBfgT/tc12SpM3YbIBX1SLgFyPavlVV67qL3wN6uyaiJGmL9WMO/O3AP25sZZIFSZYmWerhRJLUPz0FeJKzgHXABRvrU1ULq2qwqgYHBgZ62Z0kaZhxHwee5BTg94GXladaSdKEG1eAJ3kVcAZwbFU92t+SJEljMZbDCC8ClgAvTLIyyTuATwN7AFcmWZ7kf2/lOiVJI2x2BF5VJ43S/LdboRZJ0hbwTExJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktSozQZ4ks8muS/JzcPanpnkyiR3dH8/Y+uWKUkaaSwj8M8DrxrRdibwz1W1H/DP3WVJ0gTabIBX1SLgFyOaXwt8ofv4C8Dr+luWJGlzxjsHvk9VrQLo/v6tjXVMsiDJ0iRLh4aGxrk7SdJIW/1LzKpaWFWDVTU4MDCwtXcnSTuM8Qb4z5PsC9D9fV//SpIkjcV4A/xrwCndx6cA/7c/5UiSxmoshxFeBCwBXphkZZJ3AB8HXp7kDuDl3WVJ0gSaurkOVXXSRla9rM+1SJK2gGdiSlKjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRvUU4En+OMmKJDcnuSjJ9H4VJknatHEHeJLnAKcBg1V1EDAFeFO/CpMkbVqvUyhTgV2TTAV2A37We0mSpLEYd4BX1U+Bc4GfAKuAh6rqWyP7JVmQZGmSpUNDQ+OvVJL0JL1MoTwDeC0wG3g28LQkJ4/sV1ULq2qwqgYHBgbGX6kk6Ul6mUI5DvhRVQ1V1VrgMuB3+1OWJGlzegnwnwBHJdktSYCXAbf2pyxJ0ub0Mgf+feBS4AbgX7rbWtinuiRJmzG1lydX1YeBD/epFknSFvBMTElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIa1VOAJ9kryaVJbktya5Lf6VdhkqRNm9rj8/8X8M2qekOSnYHd+lCTJGkMxh3gSfYEjgHeClBVjwOP96csSdLm9DKF8u+AIeBzSW5M8jdJnjayU5IFSZYmWTo0NNTD7iRJw/US4FOBw4G/rqrDgF8BZ47sVFULq2qwqgYHBgZ62J0kabheAnwlsLKqvt9dvpROoEuSJsC4A7yq7gXuSfLCbtPLgFv6UpUkabN6PQrlVOCC7hEoPwTe1ntJkqSx6CnAq2o5MNifUiRJW8IzMSWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqN6DvAkU5LcmOSKfhQkSRqbfozA3wfc2oftSJK2QE8BnmQmcALwN/0pR5I0Vr2OwM8DPgj828Y6JFmQZGmSpUNDQz3uTpK03rgDPMnvA/dV1bJN9auqhVU1WFWDAwMD492dJGmEXkbgRwOvSXI38GXgpUm+1JeqJEmbNe4Ar6o/raqZVTULeBPw7ao6uW+VSZI2yePAJalRU/uxkaq6BrimH9uSJI2NI3BJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSo/pyIo+kiTHrzK9Pdgnblbs/fsJkl9ATR+CS1CgDXJIaZYBLUqMMcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNGneAJ/ntJFcnuTXJiiTv62dhkqRN6+VysuuAP6mqG5LsASxLcmVV3dKn2iRJmzDuEXhVraqqG7qPVwO3As/pV2GSpE3ryxx4klnAYcD3R1m3IMnSJEuHhob6sTtJEn0I8CS7A/8AvL+qHh65vqoWVtVgVQ0ODAz0ujtJUldPAZ5kGp3wvqCqLutPSZKksejlKJQAfwvcWlWf7F9JkqSx6GUEfjTwFuClSZZ3f/5jn+qSJG3GuA8jrKrrgPSxFknSFvBMTElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIa1VOAJ3lVktuT3JnkzH4VJUnavHEHeJIpwPnA8cABwElJDuhXYZKkTetlBH4kcGdV/bCqHge+DLy2P2VJkjZnag/PfQ5wz7DllcBLRnZKsgBY0F18JMntPexTTzYDuH+yi9ic/PfJrkCTwPdmfz1vtMZeAjyjtNVTGqoWAgt72I82IsnSqhqc7DqkkXxvToxeplBWAr89bHkm8LPeypEkjVUvAX49sF+S2Ul2Bt4EfK0/ZUmSNmfcUyhVtS7Je4F/AqYAn62qFX2rTGPh1JS2Vb43J0CqnjJtLUlqgGdiSlKjDHBJapQBLkmNMsAlqVG9nMijCZLk9SOais5ZbsuravUklCRtkOTwEU0F3F9V94zWX/3jUSgNSPK5UZqfCbwIeEdVfXuCS5I2SHL1KM3PBHYGTqqq5RNb0Y7DAG9YkucBf19VT7kGjTTZkgwCn6yqYya7lu2Vc+ANq6ofA9Mmuw5pNFW1FNh9suvYnhngDUvyQuCxya5DGk2SfRjlAnfqH7/EbECSy3nqP4RnAvsCJ098RdJvJPlLRn9//i7wvomvaMfhHHgDkhw7oqmAB4A7ujfTkCZNklNGNK1/f15fVfdNQkk7DAO8EUleBzwf+Jeq+qdJLkd6kiSHAf8eWFFVt052PTsK58AbkOSvgD8G9gb+PMmfTXJJ0gbd9+PFwB8AX0/yzkkuaYfhCLwBSW4GDqmqJ5LsBiyuqiMmuy4JIMkK4MVV9WiSvYFvVtWLJ7uuHYEj8DY8XlVPAFTVo4x+Oztpsqzpvi+pqgcwVyaMI/AGJHkUuHP9Ip25xvXLVNWLJqMuCSDJg8Ci9YvAf+guB6iqes0klbbdM8AbkGQ/YB9g5LUlngf8rKrufOqzpIkxylFS8JvDClNV105kPTsSjwNvw6eA/9o983KDJAPdda+elKqkjr2AmVV1PkCS/wcM0AnxMyaxru2ec1VtmFVVPxjZ2D1VedbElyM9yQd58g3NdwYGgXnAH01GQTsKR+BtmL6JdbtOWBXS6HYecenY67pfZj6Q5GmTVdSOwBF4G64f7djaJO8Alk1CPdJwzxi+UFXvHbY4MMG17FD8ErMB3YsCfQV4nN8E9iCdj6onVtW9k1WblOQC4Jqq+j8j2t8FzKuqkyansu2fAd6QJL8HHNRdXOGNHLQtSPJbwFfpXBnzhm7zEcAuwOuq6ueTVNp2zwCX1BdJXgoc2F10gDEBDHBJapRfYkpSowxwSWqUAa5mJHlkxPJbk3y6x23enWRGb5VJk8MA1w4jyVY/cS3JlK29D2k9A1zbhSSvTvL9JDcmuap77DxJPpJkYZJvAX+XZO8k3+r2+wzdS/Mm+WCS07qPP5Xk293HL0vype7jv06yNMmKJB8dtu+7k3woyXXAf0ryiiRLktyQ5JIk3pldW4UBrpbsmmT5+h/gY8PWXQccVVWHAV+mc32O9Y4AXltVbwY+TOdU78PoXL/jud0+i+hcBhU6J0ntnmQaMBdY3G0/q6oGgRcBxyYZfhnfNVU1F7gKOBs4rqoOB5YCH+jDa5eewmuhqCW/rqpD1y8keSudsAWYCVycZF86Z6j+aNjzvlZVv+4+PgZ4PUBVfT3JL7vty4AjkuzBb05IGaQT6qd1+/znJAvo/LvZFzgAWH+RsYu7v4/qtn8nCd1alvT0qqWNMMC1vfhL4JNV9bUk84CPDFv3qxF9n3LyQ1WtTXI38Dbgu3SC+ffo3Dzj1iSzgf9C59Zhv0zyeZ58kbH1+whwpaePayI4haLtxdOBn3Yfn7KJfouA+QBJjufJF2JaRCekF9GZNvkjYHl1znbbk05IP9SdXz9+I9v/HnB0kud397FbkheM6xVJm2GAa3vxEeCSJIuB+zfR76PAMUluAF4B/GTYusV0pkaWdK/fsabbRlXdBNwIrAA+C3xntI1X1RDwVuCiJD+gE+hzxv2qpE3wVHpJapQjcElqlAEuSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGvX/AahWksNN+UCGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df[df.task == \"CSV Load\"].plot(\n",
+    "    title=\"CSV Load\",\n",
+    "    kind=\"bar\",\n",
+    "    x=\"Hardware\",\n",
+    "    y=\"Seconds\",\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1acfec9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:11:48.309289Z",
+     "iopub.status.busy": "2021-12-10T19:11:48.308959Z",
+     "iopub.status.idle": "2021-12-10T19:11:48.412343Z",
+     "shell.execute_reply": "2021-12-10T19:11:48.411730Z",
+     "shell.execute_reply.started": "2021-12-10T19:11:48.309262Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEhCAYAAACEF+AUAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAaxklEQVR4nO3df5BU5Z3v8ffHEcENulEZycgQ4UZcBImDTtC7ukri73UN4sYEglmyscStoMabXCOabKK7RZWbIupWrloZr17JDxU0RvFHTMCogLLqoKPhh6wgKCMII5EIGhDG7/2jz2A79Mz0/OzMM59XVVef85zn9Pn21PDhzNPnPK2IwMzM0rJPqQswM7Ou53A3M0uQw93MLEEOdzOzBDnczcwS5HA3M0uQw92SJelaSb8odR1mpeBwtx4laZ2kP0vaLuktSXdKGljqujpD0nhJH2bvqenxUA8ef5ikkLRvTx3T/vI53K0Uzo2IgUAVMBa4urTldIkNETEw73Fue19AUll3FGZ9k8PdSiYi3gJ+Sy7kAZA0Q9IaSdskrZA0MW/b1yUtljRL0juS1ko6O2/7cElPZfvOBwblH0/SFyUtl7RV0pOSjsrbtk7SlZJelvSepNslDZb0m+z1Fkg6qL3vUdJR2bG2Zsf+Yt62OyXdKulRSe8Bn5d0mKRfSWrI3t/lef3HSaqV9K6kTZJuyDYtzJ63Zn81/M/21mnpcbhbyUiqBM4GVuc1rwH+Dvhr4DrgF5Iq8rYfD6wiF9w/Am6XpGzbXcDSbNu/A1PzjnUkcDdwBVAOPAo8JGm/vNf+R+B04EjgXOA3wDXZ6+0DXE47SOoHPAT8DjgUuAz4paS/yev2VWAmcADwTNb/JWAIcCpwhaQzs77/CfxnRBwIfAaYm7WfnD1/MvurYUl76rQ0OdytFB6QtA1YD2wGfti0ISLujYgNEfFhRMwBXgXG5e37ekTcFhGNwGygAhgs6dPA54B/jYidEbGQXFA2+QrwSETMj4hdwCxgf+Bv8/r8JCI2RcSbwCLg2Yh4MSJ2Ar8mN4TUksOys/Omx5eBE4CBwPUR8UFE/B54GJict9+DEfF0RHwIjAHKI+Lfsv6vAbcBk7K+u4AjJA2KiO0R8V+t/pStT3O4WymcFxEHAOOBkeQNn0j6J0l1TSEJHM3Hh1fealqIiPezxYHAYcA7EfFeXt/X85YPy1/PwnQ9uTPkJpvylv9cYL21D343RMQn8x5zs2Ouz46VX1P+MdfnLR9Os/8kyP3lMDjbfhG5vypekfS8pH9opR7r4/zpupVMRDwl6U5yZ9HnSTqc3JnqqcCSiGiUVAeo5VfZYyNwkKRP5AX8p4GmaU83kDszBiAbyhkKvNkV76UFG4ChkvbJC/hPA/+d1yd/Wtb1wNqIGFHoxSLiVWCypH2A84H7JB3S7DXMAJ+5W+ndBJwuqQr4BLmgagCQ9M/kztzbFBGvA7XAdZL2k3QSuXHzJnOBcySdmo2FfwfYSW6cu7s8C7wHfFdSP0njs5ruaaH/c8C7kq6StL+kMklHS/ocgKQLJZVn/1FszfZpJPfz+hD4H933Vqy3cbhbSUVEA/AzcmPlK4AfA0vIDYmMAZ5ux8t9ldwHrn8kN47/s7zjrAIuBH4CvE0uZM+NiA+64G0UlL32F8l9aPw2cAvwTxHxSgv9G7O6qoC12T7/l9yHywBnAcslbSf34eqkiNiRDU/NBJ7OhnNO6K73ZL2H/GUdZmbp8Zm7mVmCHO5mZglyuJuZJcjhbmaWoDavc5c0gNzcFf2z/vdFxA8lXQtcTHbZGnBNRDya7XM1uRsuGoHLI+K3rR1j0KBBMWzYsI6+BzOzPmnp0qVvR0R5oW3F3MS0E/hCRGzPrg9eLOk32bYbI2JWfmdJo8jdLj2a3B16CyQdmV3mVdCwYcOora0t5r2YmVlG0ustbWtzWCZytmer/bJHa9dPTgDuyeb3WEtuUqhxrfQ3M7MuVtSYe3anXB25SZ7mR8Sz2aZLsylS78ibDnUIH58vo56Pz6XR9JrTsulLaxsaGppvNjOzTigq3COiMSKqgEpgnKSjgVvJTTtaRW5ejx9n3QvNA7LXmX5E1EREdURUl5cXHDIyM7MOatfEYRGxVdKTwFn5Y+2SbiM3lSnkztSH5u1WSW4CJTMzdu3aRX19PTt27Ch1Kb3GgAEDqKyspF+/fkXvU8zVMuXArizY9wdOA/5DUkVEbMy6TQSWZcvzgLuyb4k5DBhBbkIkMzPq6+s54IADGDZsGB99z4q1JCLYsmUL9fX1DB8+vOj9ijlzrwBmK/f9jvsAcyPiYUk/z2byC2AdcElWyHJJc4EVwG5gemtXyphZ37Jjxw4HeztI4pBDDqG9n022Ge4R8TIFvoEmIr7Wyj4zyc1SZ2a2Fwd7+3Tk5+U7VM3MEuRvYjKzkho245Eufb11159TVL+ZM2dy1113UVZWxj777MNPf/pTjj/++C6tpTVPPvkks2bN4uGHH267cwc43Nuhq38J+7pi/xGadbUlS5bw8MMP88ILL9C/f3/efvttPvig2763pSQ8LGNmfc7GjRsZNGgQ/fv3B2DQoEEcdthhLF26lFNOOYXjjjuOM888k40bcxcErl69mtNOO41jjjmGY489ljVr1hARXHnllRx99NGMGTOGOXPmALkz8vHjx/OlL32JkSNHMmXKFJq+FOmxxx5j5MiRnHTSSdx///176nnqqaeoqqqiqqqKsWPHsm3btk6/R4e7mfU5Z5xxBuvXr+fII4/km9/8Jk899RS7du3isssu47777mPp0qV84xvf4Hvf+x4AU6ZMYfr06bz00ks888wzVFRUcP/991NXV8dLL73EggULuPLKK/f8Z/Diiy9y0003sWLFCl577TWefvppduzYwcUXX8xDDz3EokWLeOutt/bUM2vWLG6++Wbq6upYtGgR+++/f6ffo4dlzKzPGThwIEuXLmXRokU88cQTfOUrX+H73/8+y5Yt4/TTTwegsbGRiooKtm3bxptvvsnEiROB3A1FAIsXL2by5MmUlZUxePBgTjnlFJ5//nkOPPBAxo0bR2VlJQBVVVWsW7eOgQMHMnz4cEaMGAHAhRdeSE1NDQAnnngi3/72t5kyZQrnn3/+nn07w+FuZn1SWVkZ48ePZ/z48YwZM4abb76Z0aNHs2TJko/1e/fddwvu39r3TzcN9zQdZ/fu3UDLlzTOmDGDc845h0cffZQTTjiBBQsWMHLkyPa+pY/xsIyZ9TmrVq3i1Vdf3bNeV1fHUUcdRUNDw55w37VrF8uXL+fAAw+ksrKSBx54AICdO3fy/vvvc/LJJzNnzhwaGxtpaGhg4cKFjBvX8gS4I0eOZO3ataxZswaAu+++e8+2NWvWMGbMGK666iqqq6t55ZVXOv0efeZuZiVViqumtm/fzmWXXcbWrVvZd999OeKII6ipqWHatGlcfvnl/OlPf2L37t1cccUVjB49mp///Odccskl/OAHP6Bfv37ce++9TJw4kSVLlnDMMccgiR/96Ed86lOfajGYBwwYQE1NDeeccw6DBg3ipJNOYtmy3KwtN910E0888QRlZWWMGjWKs88+u9PvUa39adFTqqurozd8WYcvhexavhSyb1q5ciVHHXVUqcvodQr93CQtjYjqQv09LGNmliCHu5lZghzuZtbj/hKGg3uTjvy8HO5m1qMGDBjAli1bHPBFaprPven6+mL5ahkz61GVlZXU19e3e37yvqzpm5jaw+FuZj2qX79+7fpGIesYD8uYmSXI4W5mliCHu5lZghzuZmYJcribmSWozXCXNEDSc5JekrRc0nVZ+8GS5kt6NXs+KG+fqyWtlrRK0pnd+QbMzGxvxZy57wS+EBHHAFXAWZJOAGYAj0fECODxbB1Jo4BJwGjgLOAWSWXdULuZmbWgzXCPnO3Zar/sEcAEYHbWPhs4L1ueANwTETsjYi2wGmh5kmMzM+tyRY25SyqTVAdsBuZHxLPA4IjYCJA9H5p1HwKsz9u9Pmtr/prTJNVKqvWdamZmXauocI+IxoioAiqBcZKObqV7oe+R2msSiYioiYjqiKguLy8vqlgzMytOu66WiYitwJPkxtI3SaoAyJ43Z93qgaF5u1UCGzpbqJmZFa+Yq2XKJX0yW94fOA14BZgHTM26TQUezJbnAZMk9Zc0HBgBPNfFdZuZWSuKmTisApidXfGyDzA3Ih6WtASYK+ki4A3gAoCIWC5pLrAC2A1Mj4jG7infzMwKaTPcI+JlYGyB9i3AqS3sMxOY2enqzMysQ3yHqplZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJajPcJQ2V9ISklZKWS/pW1n6tpDcl1WWPv8/b52pJqyWtknRmd74BMzPb275F9NkNfCciXpB0ALBU0vxs240RMSu/s6RRwCRgNHAYsEDSkRHR2JWFm5lZy9o8c4+IjRHxQra8DVgJDGlllwnAPRGxMyLWAquBcV1RrJmZFaddY+6ShgFjgWezpkslvSzpDkkHZW1DgPV5u9VT4D8DSdMk1UqqbWhoaH/lZmbWoqLDXdJA4FfAFRHxLnAr8BmgCtgI/Lipa4HdY6+GiJqIqI6I6vLy8vbWbWZmrSgq3CX1Ixfsv4yI+wEiYlNENEbEh8BtfDT0Ug8Mzdu9EtjQdSWbmVlbirlaRsDtwMqIuCGvvSKv20RgWbY8D5gkqb+k4cAI4LmuK9nMzNpSzNUyJwJfA/4gqS5ruwaYLKmK3JDLOuASgIhYLmkusILclTbTfaWMmVnPajPcI2IxhcfRH21ln5nAzE7UZWZmneA7VM3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLUJvhLmmopCckrZS0XNK3svaDJc2X9Gr2fFDePldLWi1plaQzu/MNmJnZ3oo5c98NfCcijgJOAKZLGgXMAB6PiBHA49k62bZJwGjgLOAWSWXdUbyZmRXWZrhHxMaIeCFb3gasBIYAE4DZWbfZwHnZ8gTgnojYGRFrgdXAuC6u28zMWtGuMXdJw4CxwLPA4IjYCLn/AIBDs25DgPV5u9Vnbc1fa5qkWkm1DQ0NHSjdzMxaUnS4SxoI/Aq4IiLeba1rgbbYqyGiJiKqI6K6vLy82DLMzKwIRYW7pH7kgv2XEXF/1rxJUkW2vQLYnLXXA0Pzdq8ENnRNuWZmVoxirpYRcDuwMiJuyNs0D5iaLU8FHsxrnySpv6ThwAjgua4r2czM2rJvEX1OBL4G/EFSXdZ2DXA9MFfSRcAbwAUAEbFc0lxgBbkrbaZHRGNXF25mZi1rM9wjYjGFx9EBTm1hn5nAzE7UZWZmneA7VM3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEtRmuEu6Q9JmScvy2q6V9Kakuuzx93nbrpa0WtIqSWd2V+FmZtayYs7c7wTOKtB+Y0RUZY9HASSNAiYBo7N9bpFU1lXFmplZcdoM94hYCPyxyNebANwTETsjYi2wGhjXifrMzKwDOjPmfqmkl7Nhm4OytiHA+rw+9VmbmZn1oI6G+63AZ4AqYCPw46xdBfpGoReQNE1SraTahoaGDpZhZmaFdCjcI2JTRDRGxIfAbXw09FIPDM3rWglsaOE1aiKiOiKqy8vLO1KGmZm1oEPhLqkib3Ui0HQlzTxgkqT+koYDI4DnOleimZm1175tdZB0NzAeGCSpHvghMF5SFbkhl3XAJQARsVzSXGAFsBuYHhGN3VK5mZm1qM1wj4jJBZpvb6X/TGBmZ4oyM7PO8R2qZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSWozXCXdIekzZKW5bUdLGm+pFez54Pytl0tabWkVZLO7K7CzcysZcWcud8JnNWsbQbweESMAB7P1pE0CpgEjM72uUVSWZdVa2ZmRWkz3CNiIfDHZs0TgNnZ8mzgvLz2eyJiZ0SsBVYD47qmVDMzK1ZHx9wHR8RGgOz50Kx9CLA+r1991rYXSdMk1UqqbWho6GAZZmZWSFd/oKoCbVGoY0TURER1RFSXl5d3cRlmZn1bR8N9k6QKgOx5c9ZeDwzN61cJbOh4eWZm1hEdDfd5wNRseSrwYF77JEn9JQ0HRgDPda5EMzNrr33b6iDpbmA8MEhSPfBD4HpgrqSLgDeACwAiYrmkucAKYDcwPSIau6l2MzNrQZvhHhGTW9h0agv9ZwIzO1OUmZl1ju9QNTNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxBDnczswQ53M3MEuRwNzNLkMPdzCxB+3ZmZ0nrgG1AI7A7IqolHQzMAYYB64AvR8Q7nSvTzMzaoyvO3D8fEVURUZ2tzwAej4gRwOPZupmZ9aDuGJaZAMzOlmcD53XDMczMrBWdDfcAfidpqaRpWdvgiNgIkD0fWmhHSdMk1UqqbWho6GQZZmaWr1Nj7sCJEbFB0qHAfEmvFLtjRNQANQDV1dXRyTrMzCxPp87cI2JD9rwZ+DUwDtgkqQIge97c2SLNzKx9Ohzukj4h6YCmZeAMYBkwD5iadZsKPNjZIs3MrH06MywzGPi1pKbXuSsiHpP0PDBX0kXAG8AFnS/TzMzao8PhHhGvAccUaN8CnNqZoszMrHN8h6qZWYIc7mZmCXK4m5klyOFuZpYgh7uZWYIc7mZmCXK4m5klyOFuZpYgh7uZWYIc7mZmCXK4m5klqLPzuZvZX4hhMx4pdQnJWHf9OaUuodN85m5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZghzuZmYJcribmSXI4W5mliCHu5lZgrot3CWdJWmVpNWSZnTXcczMbG/dEu6SyoCbgbOBUcBkSaO641hmZra37jpzHwesjojXIuID4B5gQjcdy8zMmumuWSGHAOvz1uuB4/M7SJoGTMtWt0ta1U219EWDgLdLXURb9B+lrsBKwL+bXevwljZ0V7irQFt8bCWiBqjppuP3aZJqI6K61HWYNeffzZ7TXcMy9cDQvPVKYEM3HcvMzJrprnB/Hhghabik/YBJwLxuOpaZmTXTLcMyEbFb0qXAb4Ey4I6IWN4dx7KCPNxlf6n8u9lDFBFt9zIzs17Fd6iamSXI4W5mliCHu5lZghzuZmYJ6q6bmKyHSDq/WVOQuwOwLiK2laAkMwAkHdusKYC3I2J9of7WtXy1TC8n6f8VaD4Y+CxwUUT8vodLMgNA0hMFmg8G9gMmR0Rdz1bUtzjcEyXpcGBuRBzfZmezHiSpGrghIk4udS0p85h7oiLidaBfqesway4iaoGBpa4jdQ73REn6G2Bnqeswa07SYJpNJGhdzx+o9nKSHmLvfygHAxXAhT1fkVmOpJ9Q+Hfzb4Fv9XxFfYvH3Hs5Sac0awpgC/Bq9kUpZiUhaWqzpqbfzecjYnMJSupTHO4JkHQecATwh4j4bYnLMdtD0ljgM8DyiFhZ6nr6Eo+593KSbgH+F3AI8O+S/rXEJZkBkP0uzgH+EXhE0sUlLqlP8Zl7LydpGXBMRDRK+itgUUQcV+q6zCQtBz4XEe9LOgR4LCI+V+q6+gqfufd+H0REI0BEvE/hrzg0K4Ud2e8kEbEF502P8pl7LyfpfWB10yq58c2mdSLis6Woy0zSVmBh0yrwd9m6gIiIL5aotD7B4d7LSRoBDAaaz9dxOLAhIlbvvZdZ9ytwJRd8dGmkIuKpnqynr/F17r3fjcA12R2pe0gqz7adW5KqzOCTQGVE3Awg6TmgnFzAX1XCuvoEj4H1fsMi4uXmjdkt3sN6vhyzPb4LzMtb3w+oBsYD/1KKgvoSn7n3fgNa2bZ/j1Vhtrf9mk3vuzj7YHWLpE+Uqqi+wmfuvd/zha4flnQRsLQE9Zg1OSh/JSIuzVst7+Fa+hx/oNrLZZMw/Rr4gI/CvJrcn8ATI+KtUtVmfZukXwJPRsRtzdovAcZHxOTSVNY3ONwTIenzwNHZ6nJ/SYeVmqRDgQfIzU76QtZ8HNAfOC8iNpWotD7B4W5m3UrSF4DR2apPPHqIw93MLEH+QNXMLEEOdzOzBDncLQmStjdb/7qk/9PJ11wnaVDnKjMrDYe7GSCp22/ok1TW3ccwa+Jwt+RJOlfSs5JelLQguzcASddKqpH0O+Bnkg6R9Lus30/Jpk+W9F1Jl2fLN0r6fbZ8qqRfZMu3SqqVtFzSdXnHXifpB5IWAxdIOkPSEkkvSLpX0sAe/nFYH+Fwt1TsL6mu6QH8W962xcAJETEWuIfcnCdNjgMmRMRXgR+Su0V+LLk5UT6d9VlIbrpayN0gNlBSP+AkYFHW/r2IqAY+C5wiKX+q5R0RcRKwAPg+cFpEHAvUAt/ugvduthfPLWOp+HNEVDWtSPo6uSAGqATmSKogd+fu2rz95kXEn7Plk4HzASLiEUnvZO1LgeMkHcBHN+RUkwv8y7M+X5Y0jdy/qQpgFNA0oduc7PmErP1pSWS1LOnUuzZrgcPd+oKfADdExDxJ44Fr87a916zvXjd+RMQuSeuAfwaeIRfanyf3xSgrJQ0H/je5r5R7R9KdfHxCt6ZjCJjv2+6tJ3hYxvqCvwbezJanttJvITAFQNLZfHziq4XkAnwhuaGYfwHqIncX4IHkAvxP2Xj+2S28/n8BJ0o6IjvGX0k6skPvyKwNDnfrC64F7pW0CHi7lX7XASdLegE4A3gjb9sicsMtS7I5UXZkbUTES8CLwHLgDuDpQi8eEQ3A14G7Jb1MLuxHdvhdmbXC0w+YmSXIZ+5mZglyuJuZJcjhbmaWIIe7mVmCHO5mZglyuJuZJcjhbmaWoP8PpY7uMIQnL/kAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df[df.task == \"Random Forest\"].plot(\n",
+    "    title=\"Random Forest\",\n",
+    "    kind=\"bar\",\n",
+    "    x=\"Hardware\",\n",
+    "    y=\"Seconds\",\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "894f9dd9",
+   "metadata": {},
+   "source": [
+    "# Bonus: train a model with more data with a Dask cluster\n",
+    "\n",
+    "This final section of code by using a cluster of machines (each with a GPU) to train a model together with RAPIDS. This allows you to still quickly train models but no longer be limited to data that can fit on a single machine.\n",
+    "\n",
+    "This code will train a model on approximately **12x the data** as the other two, but still run as nearly quickly as with a single GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9fac0659",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:13:49.912478Z",
+     "iopub.status.busy": "2021-12-10T19:13:49.912147Z",
+     "iopub.status.idle": "2021-12-10T19:15:00.597800Z",
+     "shell.execute_reply": "2021-12-10T19:15:00.597244Z",
+     "shell.execute_reply.started": "2021-12-10T19:13:49.912440Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client, wait\n",
+    "from dask_saturn import SaturnCluster\n",
+    "import dask_cudf\n",
+    "from cuml.dask.ensemble import RandomForestClassifier as RFDask\n",
+    "\n",
+    "cluster = SaturnCluster()\n",
+    "client = Client(cluster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ae471a70",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-12-10T19:16:31.324367Z",
+     "iopub.status.busy": "2021-12-10T19:16:31.323712Z",
+     "iopub.status.idle": "2021-12-10T19:17:02.984693Z",
+     "shell.execute_reply": "2021-12-10T19:17:02.984003Z",
+     "shell.execute_reply.started": "2021-12-10T19:16:31.324329Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GPU + Dask: Random Forest: 32 seconds\n"
+     ]
+    }
+   ],
+   "source": [
+    "with timing(\"GPU + Dask: Random Forest (12x the data)\"):\n",
+    "    taxi_dask = dask_cudf.read_csv(\n",
+    "        \"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.csv\",\n",
+    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "        storage_options={\"anon\": True},\n",
+    "        assume_missing=True,\n",
+    "    )\n",
+    "\n",
+    "    X_dask = (\n",
+    "        taxi_dask[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].astype(\"float32\").fillna(-1)\n",
+    "    )\n",
+    "    y_dask = (taxi_dask[\"tip_amount\"] > 1).astype(\"int32\")\n",
+    "\n",
+    "    X_dask, y_dask = client.persist([X_dask, y_dask])\n",
+    "    _ = wait(X_dask)\n",
+    "\n",
+    "    rf_dask = RFDask(n_estimators=100)\n",
+    "    _ = rf_dask.fit(X_dask, y_dask)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e19b832f",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "As the example showed, a model using RAPIDS can be trained far more quickly than one on a CPU. RAPIDS can also run far more quickly by using Dask to connect multiple machines together."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "saturn (Python 3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is the example to support the collaborative blog post from last August

https://developer.nvidia.com/blog/zero-to-rapids-in-minutes-with-nvidia-gpus-saturn-cloud/