### PR TITLE
Bump all examples' images to use 2021.11.10 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The most important file within the `.saturn` folder is the `saturn.json` file wh
 ```json
 {
   "name": "pytorch",
-  "image_uri": "saturncloud/saturn-pytorch:2021.09.20",
+  "image_uri": "saturncloud/saturn-pytorch:2021.11.10",
   "description": "Use PyTorch with a single GPU or across multiple GPUs with Dask",
   "working_directory": "/home/jovyan/git-repos/examples/examples/pytorch",
   "extra_packages": {

--- a/examples/api/.saturn/saturn.json
+++ b/examples/api/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "image_uri": "saturncloud/saturn:2021.09.20",
+  "image_uri": "saturncloud/saturn:2021.11.10",
   "description": "Deploy an API to Saturn Cloud. Read more about deployments at: https://scld.io/docs/deployments.",
   "extra_packages": {
     "pip": "uvicorn fastapi"

--- a/examples/dashboard/.saturn/saturn.json
+++ b/examples/dashboard/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "image_uri": "saturncloud/saturn:2021.09.20",
+  "image_uri": "saturncloud/saturn:2021.11.10",
   "description": "Deploy a dashboard to Saturn Cloud. Read more about deployments at: https://scld.io/docs/deployments.",
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"

--- a/examples/dask/.saturn/saturn.json
+++ b/examples/dask/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "dask",
-  "image_uri": "saturncloud/saturn:2021.09.20",
+  "image_uri": "saturncloud/saturn:2021.11.10",
   "description": "Use distributed computing with Dask",
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"

--- a/examples/example-job/.saturn/saturn.json
+++ b/examples/example-job/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "example-job",
-  "image_uri": "saturncloud/saturn:2021.09.20",
+  "image_uri": "saturncloud/saturn:2021.11.10",
   "description": "Run a job on Saturn Cloud. Read more about jobs at: https://scld.io/docs/deployments .",
   "working_directory": "/home/jovyan/git-repos/examples/examples/example-job",
   "git_repositories": [

--- a/examples/prefect/.saturn/saturn.json
+++ b/examples/prefect/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "prefect",
-  "image_uri": "saturncloud/saturn:2021.09.20",
+  "image_uri": "saturncloud/saturn:2021.11.10",
   "description": "Scheduled jobs with Prefect and Prefect Cloud",
   "environment_variables": {
     "PREFECT_CLOUD_PROJECT_NAME": "dask-iz-gr8",

--- a/examples/pytorch/.saturn/saturn.json
+++ b/examples/pytorch/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "pytorch",
-  "image_uri": "saturncloud/saturn-pytorch:2021.09.20",
+  "image_uri": "saturncloud/saturn-pytorch:2021.11.10",
   "description": "Use PyTorch with a single GPU or across multiple GPUs with Dask",
   "environment_variables": {
     "DASK_DISTRIBUTED__WORKER__DAEMON": "False",

--- a/examples/rapids/.saturn/saturn.json
+++ b/examples/rapids/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "rapids",
-  "image_uri": "saturncloud/saturn-rapids:2021.09.20",
+  "image_uri": "saturncloud/saturn-rapids:2021.11.10",
   "description": "Use GPUs for data science and machine learning with this platform by NVIDIA",
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"

--- a/examples/snowflake-ml/.saturn/saturn.json
+++ b/examples/snowflake-ml/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflake-ml",
-  "image_uri": "saturncloud/saturn-pytorch:2021.09.20",
+  "image_uri": "saturncloud/saturn-pytorch:2021.11.10",
   "description": "Use Snowflake unstructured data for image classification with Dask",
   "environment_variables": {
     "DASK_DISTRIBUTED__WORKER__DAEMON": "False",

--- a/examples/snowflake/.saturn/saturn.json
+++ b/examples/snowflake/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "snowflake",
-  "image_uri": "saturncloud/saturn-rapids:2021.09.20",
+  "image_uri": "saturncloud/saturn-rapids:2021.11.10",
   "description": "Connect to a Snowflake database from either a single machine or distributed cluster",
   "environment_variables": {
     "TAXI_DATABASE": "saturn_nyc_taxi",

--- a/examples/tensorflow/.saturn/saturn.json
+++ b/examples/tensorflow/.saturn/saturn.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorflow",
-  "image_uri": "saturncloud/saturn-tensorflow:2021.07.26-2",
+  "image_uri": "saturncloud/saturn-tensorflow:2021.11.10",
   "description": "Train deep learning models with TensorFlow",
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"


### PR DESCRIPTION
This PR changes all of the examples to use the image tags from the 2021.11.10 builds. Most of these were on the previous tag (2021.09.20), but the `tensorflow` example was on `2021.07.26-2`. 