### PR TITLE
Update templates

### DIFF
--- a/.saturn/templates.json
+++ b/.saturn/templates.json
@@ -1,63 +1,81 @@
 {
   "templates": [
     {
-      "title": "Dask",
+      "title": "Dask (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/dask.png",
       "weight": 100,
       "recipe_path": "examples/dask/.saturn/saturn.json"
     },
     {
-      "title": "Distributed PyTorch",
+      "title": "PyTorch (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/pytorch.png",
       "weight": 200,
       "recipe_path": "examples/pytorch/.saturn/saturn.json"
     },
     {
-      "title": "RStudio",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rstudio.png",
+      "title": "Deploy a Dashboard (R)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/r-shiny.png",
       "weight": 300,
-      "recipe_path": "examples/rstudio/.saturn/saturn.json"
+      "recipe_path": "examples/r-shiny/.saturn/saturn.json"
     },
     {
-      "title": "Deploy an API",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api.png",
+      "title": "TensorFlow (R)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/tensorflow.png",
       "weight": 400,
-      "recipe_path": "examples/api/.saturn/saturn.json"
+      "recipe_path": "examples/r-tensorflow/.saturn/saturn.json"
     },
     {
-      "title": "Snowflake",
+      "title": "Snowflake (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/snowflake.png",
       "weight": 500,
       "recipe_path": "examples/snowflake/.saturn/saturn.json"
     },
     {
-      "title": "Deploy Dashboards",
+      "title": "Deploy a Dashboard (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/dashboard.png",
       "weight": 600,
       "recipe_path": "examples/dashboard/.saturn/saturn.json"
     },
     {
-      "title": "Run a job",
-      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/jobs.png",
+      "title": "Deploy an API (Python)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api.png",
       "weight": 700,
+      "recipe_path": "examples/api/.saturn/saturn.json"
+    },
+    {
+      "title": "Deploy an API (R)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api-icon.png",
+      "weight": 800,
+      "recipe_path": "examples/r-api/.saturn/saturn.json"
+    },
+    {
+      "title": "Run Jobs (Python)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/jobs.png",
+      "weight": 900,
       "recipe_path": "examples/example-job/.saturn/saturn.json"
     },
     {
-      "title": "TensorFlow",
+      "title": "Run Jobs (R)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/jobs.png",
+      "weight": 1000,
+      "recipe_path": "examples/r-job/.saturn/saturn.json"
+    },
+    {
+      "title": "TensorFlow (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/tensorflow.png",
-      "weight": 800,
+      "weight": 1100,
       "recipe_path": "examples/tensorflow/.saturn/saturn.json"
     },
     {
-      "title": "RAPIDS",
+      "title": "RAPIDS (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/rapids.png",
-      "weight": 900,
+      "weight": 1200,
       "recipe_path": "examples/rapids/.saturn/saturn.json"
     },
     {
-      "title": "Prefect",
+      "title": "Prefect (Python)",
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/prefect.png",
-      "weight": 1000,
+      "weight": 1300,
       "recipe_path": "examples/prefect/.saturn/saturn.json"
     }
   ]


### PR DESCRIPTION
This updates the template file in a few ways:

* Removes the RStudio template (we now have a button for that)
* Adds the R: jobs, deployment (dashboard), and deployment (api)
* Rearranges them slightly
* Adds the language to the title of each template.

Some of the template titles are now two lines but I think that's acceptable:

![image](https://user-images.githubusercontent.com/3317138/148715309-cf050fb8-5dc4-4b06-aa3d-94f8f837babc.png)

**Work for an upcoming PR:** Since now many of the examples tie directly to a docs page (like the two RAPIDS examples are 1:1 what's on the [RAPIDS docs page](https://saturncloud.io/docs/examples/python/rapids/), I am going to update the descriptions so they have links to the docs in them when appropriate. This is important for the jobs/deployments ones since those don't have notebooks you can read.