### PR TITLE
remove `concurrency_policy` and `backoff_limit` from non-scheduled job recipe

### DIFF
--- a/examples/autoshutoff-jupyter-kernel/.saturn/saturn.json
+++ b/examples/autoshutoff-jupyter-kernel/.saturn/saturn.json
@@ -15,8 +15,6 @@
   ],
   "job": {
     "instance_type": "medium",
-    "command": "python autoshutoff.py",
-    "concurrency_policy": "Forbid",
-    "backoff_limit": 1
+    "command": "python autoshutoff.py"
   }
 }


### PR DESCRIPTION
We have a known issue in the recipe schema that says that these two fields are allowed for non-scheduled jobs - that is not correct. For a non-scheduled job, these fields must not be present.
