### PR TITLE
Don't use ref for old-photos repo

### DIFF
--- a/examples/old-photos/.saturn/saturn.json
+++ b/examples/old-photos/.saturn/saturn.json
@@ -20,8 +20,7 @@
     {
       "url": "git@github.com:saturncloud/Bringing-Old-Photos-Back-to-Life.git",
       "path": "/home/jovyan/examples/examples/old-photos/Code",
-      "on_restart": "reclone",
-      "reference": "release-2022.01.06"
+      "on_restart": "reclone"
     }
   ],
   "jupyter_server": {


### PR DESCRIPTION
I was too aggressive in adding references to every repo listed in every saturn.json.  I think this is the only external repo that doesn't point to saturncloud/examples

Integration test run: https://github.com/saturncloud/release-images/runs/4941609587?check_suite_focus=true