### PR TITLE
Fixed characters in Dask example

### DIFF
--- a/examples/dask/machine-learning-model-training.ipynb
+++ b/examples/dask/machine-learning-model-training.ipynb
@@ -5,7 +5,7 @@
    "id": "80c42dbf-eea7-4a7e-b685-2c458cf9c9f5",
    "metadata": {},
    "source": [
-    "# Machine Learning with Dask : LightGBM, XGBoost, scikit-learn "
+    "# Machine Learning with Dask: LightGBM, XGBoost, scikit-learn "
    ]
   },
   {
@@ -105,11 +105,11 @@
    "id": "dacda41a-c440-4a9f-90c5-2f0ecc68f4d3",
    "metadata": {},
    "source": [
-    "LightGBM is a popular algorithm for supervised learning with tabular data. It has been used in many winning solutions in data science competitions. In LightGBM, like in other gradient-boosted decision tree algorithms, trees are built one node at a time. When building a tree, a set of possible “split points” (tuples of (feature, threshold)) is generated, and then each split point is evaluated. The one that leads to the best reduction in loss is chosen and added to the tree. Nodes are added to the tree this way until tree-specific stopping conditions are met. \n",
+    "LightGBM is a popular algorithm for supervised learning with tabular data. It has been used in many winning solutions in data science competitions. In LightGBM, like in other gradient-boosted decision tree algorithms, trees are built one node at a time. When building a tree, a set of possible \"split points\" (tuples of (feature, threshold)) is generated, and then each split point is evaluated. The one that leads to the best reduction in loss is chosen and added to the tree. Nodes are added to the tree this way until tree-specific stopping conditions are met. \n",
     "\n",
-    "LightGBM’s distributed training comes in two flavors: “data parallel” and “feature parallel”. For full details, see [“Optimization in Parallel Learning” (LightGBM docs)](https://lightgbm.readthedocs.io/en/latest/Features.html#optimization-in-parallel-learning).\n",
+    "LightGBM's distributed training comes in two flavors: \"data parallel\" and \"feature parallel\". For full details, see [\"Optimization in Parallel Learning\" (LightGBM docs)](https://lightgbm.readthedocs.io/en/latest/Features.html#optimization-in-parallel-learning).\n",
     "\n",
-    "The `DaskLGBMRegressor` class from `lightgbm` accepts any parameters that can be passed to `lightgbm.LGBRegressor`. Let’s use the default parameters for this example. `lightgbm.dask` model objects also come with a `predict()` method that can be used to create predictions on a Dask Array or Dask DataFrame.\n",
+    "The `DaskLGBMRegressor` class from `lightgbm` accepts any parameters that can be passed to `lightgbm.LGBRegressor`. Let's use the default parameters for this example. `lightgbm.dask` model objects also come with a `predict()` method that can be used to create predictions on a Dask Array or Dask DataFrame.\n",
     "\n",
     "Run the code below to create a validation set and test how well the model we trained in previous steps performs:"
    ]
@@ -147,9 +147,9 @@
     "\n",
     "The XGBoost Python package allows for efficient single-machine training using multithreading. However, the amount of training data you can use is limited by the size of that one machine. To solve this problem, XGBoost supports distributed training using several different interfaces. Let us see how distributed training works for XGBoost using Dask.\n",
     "\n",
-    "We will use the test and training set we had created before. `XGBoost` allows you to train on Dask collections like Dask DataFrames and Dask Arrays. This is really powerful because it means that you never have to have a single machine that’s big enough for all of your training data. For more details on this see the [XGBoost docs](https://xgboost.readthedocs.io/en/stable/tutorials/dask.html).\n",
+    "We will use the test and training set we had created before. `XGBoost` allows you to train on Dask collections like Dask DataFrames and Dask Arrays. This is really powerful because it means that you never have to have a single machine that's big enough for all of your training data. For more details on this see the [XGBoost docs](https://xgboost.readthedocs.io/en/stable/tutorials/dask.html).\n",
     "\n",
-    "Training data for `xgboost.dask` needs to be prepared in a special object called `DaskDMatrix`. This is like the XGBoost DMatrix that you might be familiar with, but is backed by Dask’s distributed collections (Dask DataFrame and Dask Array). The `train()` function from `xgboost` accepts any parameters that can be passed to `xgboost.train()`, with one exception: `nthread`. `xgboost.dask.predict()` can be used to create predictions on a Dask collection using an XGBoost model object."
+    "Training data for `xgboost.dask` needs to be prepared in a special object called `DaskDMatrix`. This is like the XGBoost DMatrix that you might be familiar with, but is backed by Dask's distributed collections (Dask DataFrame and Dask Array). The `train()` function from `xgboost` accepts any parameters that can be passed to `xgboost.train()`, with one exception: `nthread`. `xgboost.dask.predict()` can be used to create predictions on a Dask collection using an XGBoost model object."
    ]
   },
   {
@@ -191,9 +191,9 @@
    "id": "73788b6e-7583-4e2a-a064-ec9fd2fdef83",
    "metadata": {},
    "source": [
-    "Many data scientists use scikit-learn as the framework for running machine learning tasks. Conveniently, Dask is intentionally easy to integrate with scikit-learn and has strong API similarities in the dask-ml library. In this example, we’ll show you how to create a machine learning pipeline that has all the convenience of scikit-learn but adds the speed and performance of Dask. For more information about dask-ml, visit the [official docs.](https://ml.dask.org/)\n",
+    "Many data scientists use scikit-learn as the framework for running machine learning tasks. Conveniently, Dask is intentionally easy to integrate with scikit-learn and has strong API similarities in the dask-ml library. In this example, we'll show you how to create a machine learning pipeline that has all the convenience of scikit-learn but adds the speed and performance of Dask. For more information about dask-ml, visit the [official docs.](https://ml.dask.org/)\n",
     "\n",
-    "We’ll train a linear model to predict sale price of houses. We define a Pipeline to encompass both feature scaling and model training. This will be useful in cases like performing a grid search."
+    "We'll train a linear model to predict sale price of houses. We define a Pipeline to encompass both feature scaling and model training. This will be useful in cases like performing a grid search."
    ]
   },
   {
@@ -220,7 +220,7 @@
    "id": "fdaf1bce-e44d-42c2-a07d-8c03d6fbc500",
    "metadata": {},
    "source": [
-    "Now we are ready to train our model. Before we train, we’ll convert our testing and training sets from dask.dataframe objects to dask.array objects. We’ll also take this chance to precompute the chunksize of our arrays."
+    "Now we are ready to train our model. Before we train, we'll convert our testing and training sets from dask.dataframe objects to dask.array objects. We'll also take this chance to precompute the chunksize of our arrays."
    ]
   },
   {


### PR DESCRIPTION
Because of how we move code onto our docs page, the character `’` among others breaks our script. For now let's just take them out of the code