### PR TITLE
Clean up dask imports

### DIFF
--- a/examples/dask/dask-collections-dask-array.ipynb
+++ b/examples/dask/dask-collections-dask-array.ipynb
@@ -119,11 +119,11 @@
    },
    "outputs": [],
    "source": [
-    "from dask.dataframe import from_pandas\n",
     "import pandas as pd\n",
+    "import dask.dataframe as dd\n",
     "\n",
     "df = pd.DataFrame([{\"x\": 1, \"y\": 2, \"z\": 3}, {\"x\": 4, \"y\": 5, \"z\": 6}])\n",
-    "df1 = from_pandas(df, npartitions=1)\n",
+    "df1 = dd.from_pandas(df, npartitions=1)\n",
     "x = df1.to_dask_array()\n",
     "x.compute()"
    ]

--- a/examples/dask/dask-collections-dask-bag.ipynb
+++ b/examples/dask/dask-collections-dask-bag.ipynb
@@ -88,8 +88,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dask.bag as db\n",
-    "\n",
     "x = db.read_text(\n",
     "    [\n",
     "        \"s3://saturn-public-data/examples/Dask/1.json\",\n",
@@ -120,7 +118,6 @@
    },
    "outputs": [],
    "source": [
-    "import dask.bag as db\n",
     "import json\n",
     "\n",
     "b = db.read_text(\n",

--- a/examples/dask/dask-collections-dask-dataframe.ipynb
+++ b/examples/dask/dask-collections-dask-dataframe.ipynb
@@ -104,14 +104,13 @@
    },
    "outputs": [],
    "source": [
-    "from dask.dataframe import from_pandas\n",
     "import pandas as pd\n",
     "\n",
     "data = [{\"x\": 1, \"y\": 2, \"z\": 3}, {\"x\": 4, \"y\": 5, \"z\": 6}]\n",
     "\n",
     "# Creates DataFrame.\n",
     "df = pd.DataFrame(data)\n",
-    "df1 = from_pandas(df, npartitions=1)\n",
+    "df1 = dd.from_pandas(df, npartitions=1)\n",
     "df1.compute()"
    ]
   },
@@ -159,8 +158,6 @@
    },
    "outputs": [],
    "source": [
-    "import dask.dataframe as dd\n",
-    "\n",
     "f1 = dd.read_csv(\n",
     "    \"s3://saturn-public-data/examples/Dask/f1_laptime.csv\", storage_options={\"anon\": True}\n",
     ")\n",


### PR DESCRIPTION
Removing duplicated imports and using `dd` directly instead of importing from `dask.dataframe`

Integration test: https://github.com/saturncloud/release-images/runs/4968462324?check_suite_focus=true

Integration tests seem to not be working on this branch for unrelated reasons, but I tested this on hosted and it seems fine.