### PR TITLE
correct example working_directory

### DIFF
--- a/examples/rapids-comparison/.saturn/saturn.json
+++ b/examples/rapids-comparison/.saturn/saturn.json
@@ -5,7 +5,7 @@
   "environment_variables": {
     "SATURN__JUPYTER_SETUP_DASK_WORKSPACE": "true"
   },
-  "working_directory": "/home/jovyan/examples/examples/rapids",
+  "working_directory": "/home/jovyan/examples/examples/rapids-comparison",
   "git_repositories": [
     {
       "url": "https://github.com/saturncloud/examples",


### PR DESCRIPTION
Turns out, this is a very subtle way to make our `integration-tests` break. We should probably add a CI check for this at some point.