### PR TITLE
handling error for rapids-comparison

### DIFF
--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -97,8 +97,7 @@
     "\n",
     "with timing(\"CPU: CSV Load\"):\n",
     "    taxi_cpu = pd.read_csv(\n",
-    "        \"data.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "        \"data.csv\", parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
     "    )\n",
     "\n",
     "X_cpu = taxi_cpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].fillna(-1)\n",
@@ -140,8 +139,7 @@
     "\n",
     "with timing(\"GPU: CSV Load\"):\n",
     "    taxi_gpu = cudf.read_csv(\n",
-    "        \"data.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "        \"data.csv\", parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
     "    )\n",
     "\n",
     "X_gpu = taxi_gpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].astype(\"float32\").fillna(-1)\n",
@@ -202,10 +200,7 @@
    "outputs": [],
    "source": [
     "df[df.task == \"CSV Load\"].plot(\n",
-    "    title=\"CSV Load\",\n",
-    "    kind=\"bar\",\n",
-    "    x=\"Hardware\",\n",
-    "    y=\"Seconds\",\n",
+    "    title=\"CSV Load\", kind=\"bar\", x=\"Hardware\", y=\"Seconds\",\n",
     ");"
    ]
   },
@@ -225,10 +220,7 @@
    "outputs": [],
    "source": [
     "df[df.task == \"Random Forest\"].plot(\n",
-    "    title=\"Random Forest\",\n",
-    "    kind=\"bar\",\n",
-    "    x=\"Hardware\",\n",
-    "    y=\"Seconds\",\n",
+    "    title=\"Random Forest\", kind=\"bar\", x=\"Hardware\", y=\"Seconds\",\n",
     ");"
    ]
   },
@@ -299,7 +291,7 @@
     "    X_dask, y_dask = client.persist([X_dask, y_dask])\n",
     "    _ = wait(X_dask)\n",
     "\n",
-    "    rf_dask = RFDask(n_estimators=100)\n",
+    "    rf_dask = RFDask(n_estimators=100, ignore_empty_partitions=True)\n",
     "    _ = rf_dask.fit(X_dask, y_dask)"
    ]
   },
@@ -316,7 +308,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "saturn (Python 3)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -330,7 +322,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since the error “ValueError: Data was not split among all workers“ is recurring, I have added “ignore_empty_partitions“ parameter to random forest. This ensures that there is no failure when there are empty partitions .
This error can occur while loading the data or while filtering the dataframe.
other ways to handle this would be 1. to apply repartition 2. Explicitly remove empty .
But to keep it more understandable we have used simplest approach.