### PR TITLE
error handling rapids-comparison

### DIFF
--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -299,7 +299,7 @@
     "    X_dask, y_dask = client.persist([X_dask, y_dask])\n",
     "    _ = wait(X_dask)\n",
     "\n",
-    "    rf_dask = RFDask(n_estimators=100)\n",
+    "    rf_dask = RFDask(n_estimators=100,ignore_empty_partitions=True)\n",
     "    _ = rf_dask.fit(X_dask, y_dask)"
    ]
   },
@@ -316,7 +316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "saturn (Python 3)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -330,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -299,7 +299,7 @@
     "    X_dask, y_dask = client.persist([X_dask, y_dask])\n",
     "    _ = wait(X_dask)\n",
     "\n",
-    "    rf_dask = RFDask(n_estimators=100,ignore_empty_partitions=True)\n",
+    "    rf_dask = RFDask(n_estimators=100, ignore_empty_partitions=True)\n",
     "    _ = rf_dask.fit(X_dask, y_dask)"
    ]
   },


### PR DESCRIPTION
Since the error “ValueError: Data was not split among all workers“ is recurring, I have added “ignore_empty_partitions“ parameter to random forest. This ensures that there is no failure when there are empty partitions .
This error can occur while loading the data or while filtering the dataframe.
other ways to handle this would be 1. to apply repartition 2. Explicitly remove empty .
But to keep it more understandable we have used simplest approach.