### PR TITLE
add reference for single gpu example

### DIFF
--- a/examples/tensorflow-multigpu/multi-gpu-tensorflow.ipynb
+++ b/examples/tensorflow-multigpu/multi-gpu-tensorflow.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "## Overview\n",
     "\n",
-    "This example builds on [Single-Node Single GPU Training in TensorFlow](./01-tensorflow-single-gpu.ipynb). It trains a Resnet50 model on a dataset of bird images to identify different species of birds. In this example, we will be using multiple GPUs. We will parallelize the learning by using TensorFlow Mirrored Strategy. The model will split the data in each batch (sometimes called a \"global batch\") across the GPUs, thereby making \"worker batches.\" Each GPU has a copy of the model, called a \"replica,\" and after they learn on different parts of each batch, they will combine the learned gradients at the end of the step. The result at the end of training is one model that has learned on all the data.\n",
+    "This example builds on [Single-Node Single GPU Training in TensorFlow](https://saturncloud.io/docs/examples/python/tensorflow/qs-single-gpu-tensorflow/). It trains a Resnet50 model on a dataset of bird images to identify different species of birds. In this example, we will be using multiple GPUs. We will parallelize the learning by using TensorFlow Mirrored Strategy. The model will split the data in each batch (sometimes called a \"global batch\") across the GPUs, thereby making \"worker batches.\" Each GPU has a copy of the model, called a \"replica,\" and after they learn on different parts of each batch, they will combine the learned gradients at the end of the step. The result at the end of training is one model that has learned on all the data.\n",
     "\n",
     "This dataset consists of 40,000+ images of birds and has been taken from [kaggle](https://www.kaggle.com/gpiosenka/100-bird-species).\n",
     "\n",


### PR DESCRIPTION
added a reference to docs for single gpu example for tensorflow. This will make it easy to refer to the single gpu docs when we convert notebooks to md