### PR TITLE
add julia examples to templates

### DIFF
--- a/.saturn/templates-enterprise.json
+++ b/.saturn/templates-enterprise.json
@@ -83,6 +83,24 @@
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/prefect.png",
       "weight": 1300,
       "recipe_path": "examples/prefect/.saturn/saturn.json"
+    },
+    {
+      "title": "Flux (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/flux-logo.png",
+      "weight": 1500,
+      "recipe_path": "examples/julia-flux/.saturn/saturn.json"
+    },
+    {
+      "title": "Deploy a Dashboard (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/julia-dashboard.png",
+      "weight": 1600,
+      "recipe_path": "examples/julia-dashboard-dash/.saturn/saturn.json"
+    },
+    {
+      "title": "Deploy an API (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api-icon.png",
+      "weight": 1700,
+      "recipe_path": "examples/julia-api/.saturn/saturn.json"
     }
   ]
 }

--- a/.saturn/templates-hosted.json
+++ b/.saturn/templates-hosted.json
@@ -83,6 +83,24 @@
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/prefect.png",
       "weight": 1300,
       "recipe_path": "examples/prefect/.saturn/saturn.json"
+    },
+    {
+      "title": "Flux (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/flux-logo.png",
+      "weight": 1500,
+      "recipe_path": "examples/julia-flux/.saturn/saturn.json"
+    },
+    {
+      "title": "Deploy a Dashboard (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/julia-dashboard.png",
+      "weight": 1600,
+      "recipe_path": "examples/julia-dashboard-dash/.saturn/saturn.json"
+    },
+    {
+      "title": "Deploy an API (Julia)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/api-icon.png",
+      "weight": 1700,
+      "recipe_path": "examples/julia-api/.saturn/saturn.json"
     }
   ]
 }


### PR DESCRIPTION
Adds the Julia examples to the templates (both enterprise and hosted). Not sure where we want to feature them in the list - they are at the end for the time being.
