### PR TITLE
Add disk_space to example workspaces missing it, added validation check

### DIFF
--- a/.ci/validate-examples.py
+++ b/.ci/validate-examples.py
@@ -130,6 +130,7 @@ def validate_recipe(schema, instance_type_options, recipe_path, example_dir):
     job = recipe.get("job")
     rstudio = recipe.get("rstudio_server")
     resource = jupyter or deployment or job or rstudio
+    workspace = jupyter or rstudio
 
     if resource["instance_type"] not in instance_type_options:
         raise ValidationError(
@@ -146,6 +147,9 @@ def validate_recipe(schema, instance_type_options, recipe_path, example_dir):
                 "Dask worker instance type should match the instance type "
                 "of its attached jupyter_server or deployment"
             )
+
+    if workspace is not None and "disk_space" not in workspace:
+        raise ValidationError("disk_space is required for workspaces.")
 
 
 def image_exists_on_registry(registry: Optional[str], image_name: str, image_tag: str) -> bool:

--- a/examples/bodo/.saturn/saturn.json
+++ b/examples/bodo/.saturn/saturn.json
@@ -14,7 +14,8 @@
         }
     ],
     "jupyter_server": {
-        "instance_type": "2xlarge"
+        "instance_type": "2xlarge",
+        "disk_space": "10Gi"
     },
     "version": "2022.01.06"
 }

--- a/examples/dask-gpu-experiment/.saturn/saturn.json
+++ b/examples/dask-gpu-experiment/.saturn/saturn.json
@@ -14,7 +14,8 @@
     }
   ],
   "jupyter_server": {
-    "instance_type": "g4dnxlarge"
+    "instance_type": "g4dnxlarge",
+    "disk_space": "10Gi"
   },
   "dask_cluster": {
     "num_workers": 3,


### PR DESCRIPTION
When #345 merged, this added the Bodo example to the templates lists, which broke our internal CI tests on another repo because, while the 2022.01.06 resource schema technically does not require `disk_space` on jupyter or rstudio servers, our applications currently require it to be set. This PR adds a validation check for that to this repo, and adds disk_space to the two examples that were missing it.