### PR TITLE
Update bodo

### DIFF
--- a/examples/bodo/README.md
+++ b/examples/bodo/README.md
@@ -2,13 +2,14 @@
 
 Bodo is an HPC-style framework built around native Python. It provides serious performance improvements to your code with its compiler technology. These examples are adapted from the [Bodo.ai example repository](https://github.com/Bodo-inc/Bodo-examples).
 
->**Note**: Bodo works best for very large datasets, so downloading the data used in the examples can take some time. Please be patient while the datasets download for each example - you will see the speed benefits of Bodo when manipulating the downloaded data.
+> **Note**: Bodo works best for very large datasets, so downloading the data used in the examples can take some time. Please be patient while the datasets download for each example - you will see the speed benefits of Bodo when manipulating the downloaded data.
 
-There are two types of examples in this repository - notebook and terminal. The notebook example runs in a Jupyter notebook session using iPyParallel. The terminal example runs using mpiexec in a terminal environment.
+There are two types of examples in this repository - notebook and terminal. The notebook examples run in a Jupyter notebook session using iPyParallel. The terminal example runs using mpiexec in a terminal environment.
 
 The free Bodo Community Edition allows for using Bodo on up to 8 parallel cores. If you have a Bodo Enterprise license key, add it as an environment variable (under advanced settings) in the resource definition screen to run the examples on more than 8 cores.
 
----------------------------
+---
+
 More documentation can be found at http://docs.bodo.ai.
 
 Also take a look at [the Bodo tutorial](https://github.com/Bodo-inc/Bodo-tutorial) for more inspiration.

--- a/examples/bodo/bodo-eda-chicago-crimes.ipynb
+++ b/examples/bodo/bodo-eda-chicago-crimes.ipynb
@@ -98,7 +98,10 @@
     "@bodo.jit(cache=True)\n",
     "def load_chicago_crimes():\n",
     "    t1 = time.time()\n",
-    "    crimes = pd.read_parquet('s3://bodo-example-data/chicago-crimes/Chicago_Crimes_2012_to_2017.pq')\n",
+    "    crimes = pd.read_parquet(\n",
+    "        's3://bodo-example-data/chicago-crimes/Chicago_Crimes_2012_to_2017.pq', \n",
+    "        storage_options={'anon': True}\n",
+    "        )\n",
     "    crimes = crimes.sort_values(by=\"ID\")    \n",
     "    print(\"Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")    \n",
     "    return crimes\n",
@@ -419,11 +422,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b9413a73",
+   "metadata": {},
+   "source": [
+    "## Stopping the cluster\n",
+    "\n",
+    "When you're done using the parallel cluster you can shut it down with a single command. Note that since the cluster is running within the same Jupyter Server resource as the notebook, there is no change to what hardware is running after you stop it (since the resource is still on)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "conditional-hindu",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-03-30T23:47:17.192025Z",
+     "iopub.status.busy": "2022-03-30T23:47:17.191835Z",
+     "iopub.status.idle": "2022-03-30T23:47:17.194517Z",
+     "shell.execute_reply": "2022-03-30T23:47:17.193814Z",
+     "shell.execute_reply.started": "2022-03-30T23:47:17.192006Z"
+    },
+    "tags": []
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "# command to stop the cluster\n",
+    "rc.cluster.stop_cluster_sync()"
+   ]
   }
  ],
  "metadata": {

--- a/examples/bodo/bodo-model-training-nyc-taxi.ipynb
+++ b/examples/bodo/bodo-model-training-nyc-taxi.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "These are the main packages we are going to work with:\n",
     " - Bodo to parallelize Python code automatically\n",
-    " - Pandas to work with data\n",
+    " - pandas to work with data\n",
     " - scikit-learn to build and evaluate regression models\n",
     " - xgboost for xgboost regressor model"
    ]
@@ -157,6 +157,7 @@
     "    start = time.time()\n",
     "    taxi = pd.read_parquet(\n",
     "        \"s3://bodo-example-data/nyc-taxi/yellow_tripdata_2019_half.pq\",\n",
+    "        storage_options={\"anon\": True}\n",
     "        )\n",
     "    print(\"Reading time: \", time.time() - start)\n",
     "    print(taxi.shape)\n",

--- a/examples/bodo/bodo-tpch.ipynb
+++ b/examples/bodo/bodo-tpch.ipynb
@@ -15,9 +15,6 @@
     "\n",
     "Dataset size is 2GB.\n",
     "\n",
-    "There's a larger dataset available on \"s3://bodo-example-data/tpch/s4/\" which is 4GB. \n",
-    "\n",
-    "\n",
     "**The Bodo parallel cluster in this example runs within the same Saturn Cloud resource as the notebook.** Thus, to increase the performance of the Bodo cluster you only need to increase the instance size of the Jupyter Server resource it's running on.\n",
     "\n",
     "**To scale and run your application with multiple nodes you can use [Bodo platform](https://platform.bodo.ai/account/login)**"
@@ -51,19 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following code imports bodo and verifies that the IPyParallel cluster is set up correctly"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "import bodo\n",
-    "\n",
-    "print(f\"Hello World from rank {bodo.get_rank()}. Total ranks={bodo.get_size()}\")"
+    "The following code imports bodo and other standard libraries and verifies that the IPyParallel cluster is set up correctly"
    ]
   },
   {
@@ -71,11 +56,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:48:34.551756Z",
-     "iopub.status.busy": "2022-04-04T23:48:34.551374Z",
-     "iopub.status.idle": "2022-04-04T23:48:44.880272Z",
-     "shell.execute_reply": "2022-04-04T23:48:44.879646Z",
-     "shell.execute_reply.started": "2022-04-04T23:48:34.551724Z"
+     "iopub.execute_input": "2022-04-25T18:03:43.616460Z",
+     "iopub.status.busy": "2022-04-25T18:03:43.616170Z",
+     "iopub.status.idle": "2022-04-25T18:03:54.114821Z",
+     "shell.execute_reply": "2022-04-25T18:03:54.114285Z",
+     "shell.execute_reply.started": "2022-04-25T18:03:43.616427Z"
     },
     "tags": []
    },
@@ -85,7 +70,9 @@
     "import bodo\n",
     "import time\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "\n",
+    "print(f\"Hello World from rank {bodo.get_rank()}. Total ranks={bodo.get_size()}\")"
    ]
   },
   {
@@ -103,11 +90,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:54:30.313575Z",
-     "iopub.status.busy": "2022-04-04T23:54:30.313229Z",
-     "iopub.status.idle": "2022-04-04T23:55:00.160599Z",
-     "shell.execute_reply": "2022-04-04T23:55:00.160033Z",
-     "shell.execute_reply.started": "2022-04-04T23:54:30.313546Z"
+     "iopub.execute_input": "2022-04-25T18:03:54.142979Z",
+     "iopub.status.busy": "2022-04-25T18:03:54.142750Z",
+     "iopub.status.idle": "2022-04-25T18:04:00.362708Z",
+     "shell.execute_reply": "2022-04-25T18:04:00.361903Z",
+     "shell.execute_reply.started": "2022-04-25T18:03:54.142947Z"
     },
     "tags": []
    },
@@ -117,22 +104,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_lineitem(data_folder):\n",
     "    t1 = time.time()\n",
-    "    file = data_folder + \"/lineitem.tbl\"\n",
-    "    cols_names = ['L_ORDERKEY' , 'L_PARTKEY', 'L_SUPPKEY', 'L_LINENUMBER', 'L_QUANTITY',\n",
-    "            'L_EXTENDEDPRICE', 'L_DISCOUNT', 'L_TAX', 'L_RETURNFLAG', 'L_LINESTATUS', 'L_SHIPDATE',\n",
-    "            'L_COMMITDATE', 'L_RECEIPTDATE', 'L_SHIPINSTRUCT', 'L_SHIPMODE', 'L_COMMENT']\n",
-    "    cols = {'L_ORDERKEY' : np.int64, 'L_PARTKEY' : np.int64, 'L_SUPPKEY' : np.int64, 'L_LINENUMBER' : np.int64, 'L_QUANTITY' : np.float64,\n",
-    "            'L_EXTENDEDPRICE' : np.float64, 'L_DISCOUNT' : np.float64, 'L_TAX' : np.float64, 'L_RETURNFLAG' : str, 'L_LINESTATUS' : str, 'L_SHIPDATE' : str,\n",
-    "            'L_COMMITDATE' : str, 'L_RECEIPTDATE' : str, 'L_SHIPINSTRUCT' : str, 'L_SHIPMODE' : str, 'L_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols,\n",
-    "        parse_dates=[10, 11, 12]\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Lineitem Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "\n",
-    "lineitem = load_lineitem(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "lineitem = load_lineitem(\"s3://bodo-example-data/tpch/s2/lineitem.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(lineitem.head())"
    ]
@@ -142,11 +118,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:00.161910Z",
-     "iopub.status.busy": "2022-04-04T23:55:00.161643Z",
-     "iopub.status.idle": "2022-04-04T23:55:08.008948Z",
-     "shell.execute_reply": "2022-04-04T23:55:08.008375Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:00.161873Z"
+     "iopub.execute_input": "2022-04-25T18:04:01.377032Z",
+     "iopub.status.busy": "2022-04-25T18:04:01.376756Z",
+     "iopub.status.idle": "2022-04-25T18:04:03.846092Z",
+     "shell.execute_reply": "2022-04-25T18:04:03.845614Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:01.377009Z"
     },
     "scrolled": true,
     "tags": []
@@ -158,22 +134,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_orders(data_folder):\n",
     "    t1 = time.time()    \n",
-    "    file = data_folder + \"/orders.tbl\"\n",
-    "    cols_names = ['O_ORDERKEY', 'O_CUSTKEY', 'O_ORDERSTATUS',\n",
-    "            'O_TOTALPRICE', 'O_ORDERDATE', 'O_ORDERPRIORITY',\n",
-    "            'O_CLERK', 'O_SHIPPRIORITY', 'O_COMMENT']\n",
-    "    cols = {'O_ORDERKEY' : np.int64, 'O_CUSTKEY' : np.int64, 'O_ORDERSTATUS' : str,\n",
-    "            'O_TOTALPRICE' : np.float64, 'O_ORDERDATE' : np.int64, 'O_ORDERPRIORITY' : str,\n",
-    "            'O_CLERK' : str, 'O_SHIPPRIORITY' : np.int64, 'O_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols,\n",
-    "        parse_dates=[4]\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Orders Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "    \n",
-    "orders = load_orders(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "orders = load_orders(\"s3://bodo-example-data/tpch/s2/orders.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(orders.head())"
    ]
@@ -183,11 +148,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:08.009872Z",
-     "iopub.status.busy": "2022-04-04T23:55:08.009682Z",
-     "iopub.status.idle": "2022-04-04T23:55:11.438365Z",
-     "shell.execute_reply": "2022-04-04T23:55:11.437731Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:08.009846Z"
+     "iopub.execute_input": "2022-04-25T18:04:06.045158Z",
+     "iopub.status.busy": "2022-04-25T18:04:06.044883Z",
+     "iopub.status.idle": "2022-04-25T18:04:07.839067Z",
+     "shell.execute_reply": "2022-04-25T18:04:07.838194Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:06.045136Z"
     },
     "tags": []
    },
@@ -198,23 +163,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_customer(data_folder):\n",
     "    t1 = time.time()\n",
-    "    file = data_folder + \"/customer.tbl\"\n",
-    "    cols_names = ['C_CUSTKEY', 'C_NAME',\n",
-    "            'C_ADDRESS', 'C_NATIONKEY',\n",
-    "            'C_PHONE', 'C_ACCTBAL',\n",
-    "            'C_MKTSEGMENT', 'C_COMMENT']\n",
-    "    cols = {'C_CUSTKEY' : np.int64, 'C_NAME' : str,\n",
-    "            'C_ADDRESS' : str, 'C_NATIONKEY' : np.int64,\n",
-    "            'C_PHONE' : str, 'C_ACCTBAL' : np.float64,\n",
-    "            'C_MKTSEGMENT' : str, 'C_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Customer Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "\n",
-    "customer = load_customer(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "customer = load_customer(\"s3://bodo-example-data/tpch/s2/customers.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(customer.head())"
    ]
@@ -224,11 +177,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:11.439816Z",
-     "iopub.status.busy": "2022-04-04T23:55:11.439565Z",
-     "iopub.status.idle": "2022-04-04T23:55:13.781355Z",
-     "shell.execute_reply": "2022-04-04T23:55:13.780787Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:11.439789Z"
+     "iopub.execute_input": "2022-04-25T18:04:08.336424Z",
+     "iopub.status.busy": "2022-04-25T18:04:08.336154Z",
+     "iopub.status.idle": "2022-04-25T18:04:09.446043Z",
+     "shell.execute_reply": "2022-04-25T18:04:09.445592Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:08.336401Z"
     },
     "tags": []
    },
@@ -239,19 +192,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_nation(data_folder):\n",
     "    t1 = time.time()\n",
-    "    file = data_folder + \"/nation.tbl\"\n",
-    "    cols_names = ['N_NATIONKEY', 'N_NAME',\n",
-    "            'N_REGIONKEY', 'N_COMMENT']\n",
-    "    cols = {'N_NATIONKEY' : np.int64, 'N_NAME' : str,\n",
-    "            'N_REGIONKEY' : np.int64, 'N_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Nation Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "\n",
-    "nation = load_nation(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "nation = load_nation(\"s3://bodo-example-data/tpch/s2/nation.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(nation.head())"
    ]
@@ -261,11 +206,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:13.782273Z",
-     "iopub.status.busy": "2022-04-04T23:55:13.782089Z",
-     "iopub.status.idle": "2022-04-04T23:55:16.307358Z",
-     "shell.execute_reply": "2022-04-04T23:55:16.306782Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:13.782248Z"
+     "iopub.execute_input": "2022-04-25T18:04:10.612100Z",
+     "iopub.status.busy": "2022-04-25T18:04:10.611826Z",
+     "iopub.status.idle": "2022-04-25T18:04:11.989710Z",
+     "shell.execute_reply": "2022-04-25T18:04:11.989003Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:10.612077Z"
     },
     "tags": []
    },
@@ -276,21 +221,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_supplier(data_folder):\n",
     "    t1 = time.time()    \n",
-    "    file = data_folder + \"/supplier.tbl\"\n",
-    "    cols_names = ['S_SUPPKEY', 'S_NAME', 'S_ADDRESS',\n",
-    "            'S_NATIONKEY', 'S_PHONE', 'S_ACCTBAL',\n",
-    "            'S_COMMENT']\n",
-    "    cols = {'S_SUPPKEY' : np.int64, 'S_NAME' : str, 'S_ADDRESS' : str,\n",
-    "            'S_NATIONKEY' : np.int64, 'S_PHONE' : str, 'S_ACCTBAL' : np.float64,\n",
-    "            'S_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Supplier Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")     \n",
     "    return rel\n",
     "\n",
-    "supplier = load_supplier(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "supplier = load_supplier(\"s3://bodo-example-data/tpch/s2/supplier.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(supplier.head())"
    ]
@@ -300,11 +235,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:16.308702Z",
-     "iopub.status.busy": "2022-04-04T23:55:16.308135Z",
-     "iopub.status.idle": "2022-04-04T23:55:21.736663Z",
-     "shell.execute_reply": "2022-04-04T23:55:21.736102Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:16.308666Z"
+     "iopub.execute_input": "2022-04-25T18:04:11.990594Z",
+     "iopub.status.busy": "2022-04-25T18:04:11.990398Z",
+     "iopub.status.idle": "2022-04-25T18:04:13.841762Z",
+     "shell.execute_reply": "2022-04-25T18:04:13.840776Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:11.990573Z"
     },
     "tags": []
    },
@@ -315,19 +250,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_partsupp(data_folder):\n",
     "    t1 = time.time()\n",
-    "    file = data_folder + \"/partsupp.tbl\"\n",
-    "    cols_names = ['PS_PARTKEY', 'PS_SUPPKEY', 'PS_AVAILQTY',\n",
-    "            'PS_SUPPLYCOST', 'PS_COMMENT']\n",
-    "    cols = {'PS_PARTKEY' : np.int64, 'PS_SUPPKEY' : np.int64, 'PS_AVAILQTY' : np.int64,\n",
-    "            'PS_SUPPLYCOST' : np.float64, 'PS_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Partsupp Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "\n",
-    "partsupp = load_partsupp(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "partsupp = load_partsupp(\"s3://bodo-example-data/tpch/s2/partsupp.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(partsupp.head())"
    ]
@@ -337,11 +264,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:21.737712Z",
-     "iopub.status.busy": "2022-04-04T23:55:21.737456Z",
-     "iopub.status.idle": "2022-04-04T23:55:25.239911Z",
-     "shell.execute_reply": "2022-04-04T23:55:25.239345Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:21.737685Z"
+     "iopub.execute_input": "2022-04-25T18:04:13.842675Z",
+     "iopub.status.busy": "2022-04-25T18:04:13.842467Z",
+     "iopub.status.idle": "2022-04-25T18:04:15.126676Z",
+     "shell.execute_reply": "2022-04-25T18:04:15.125961Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:13.842653Z"
     },
     "tags": []
    },
@@ -352,21 +279,11 @@
     "@bodo.jit(distributed=[\"rel\"], cache=True)\n",
     "def load_part(data_folder):\n",
     "    t1 = time.time()\n",
-    "    file = data_folder + \"/part.tbl\"\n",
-    "    cols_names = ['P_PARTKEY', 'P_NAME', 'P_MFGR', 'P_BRAND',\n",
-    "            'P_TYPE', 'P_SIZE', 'P_CONTAINER',\n",
-    "            'P_RETAILPRICE', 'P_COMMENT']\n",
-    "    cols = {'P_PARTKEY' : np.int64, 'P_NAME' : str, 'P_MFGR' : str, 'P_BRAND' : str,\n",
-    "            'P_TYPE' : str, 'P_SIZE' : np.int64, 'P_CONTAINER' : str,\n",
-    "            'P_RETAILPRICE' : np.float64, 'P_COMMENT' : str}\n",
-    "    rel = pd.read_csv(file, sep='|', header=None,\n",
-    "        names=cols_names,\n",
-    "        dtype=cols\n",
-    "        )\n",
+    "    rel = pd.read_parquet(data_folder, storage_options={\"anon\": True})\n",
     "    print(\"Part Reading time: \", ((time.time() - t1) * 1000), \" (ms)\")\n",
     "    return rel\n",
     "\n",
-    "part = load_part(\"s3://bodo-examples-data/tpch/s2\")\n",
+    "part = load_part(\"s3://bodo-example-data/tpch/s2/part.pq\")\n",
     "if bodo.get_rank()==0:\n",
     "    display(part.head())"
    ]
@@ -395,11 +312,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:34.467415Z",
-     "iopub.status.busy": "2022-04-04T23:55:34.467068Z",
-     "iopub.status.idle": "2022-04-04T23:55:46.548390Z",
-     "shell.execute_reply": "2022-04-04T23:55:46.547788Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:34.467378Z"
+     "iopub.execute_input": "2022-04-25T18:04:15.750257Z",
+     "iopub.status.busy": "2022-04-25T18:04:15.749983Z",
+     "iopub.status.idle": "2022-04-25T18:04:16.320378Z",
+     "shell.execute_reply": "2022-04-25T18:04:16.319886Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:15.750230Z"
     },
     "tags": []
    },
@@ -443,11 +360,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:46.549671Z",
-     "iopub.status.busy": "2022-04-04T23:55:46.549418Z",
-     "iopub.status.idle": "2022-04-04T23:55:56.122119Z",
-     "shell.execute_reply": "2022-04-04T23:55:56.121522Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:46.549643Z"
+     "iopub.execute_input": "2022-04-25T18:04:18.435917Z",
+     "iopub.status.busy": "2022-04-25T18:04:18.435648Z",
+     "iopub.status.idle": "2022-04-25T18:04:18.671081Z",
+     "shell.execute_reply": "2022-04-25T18:04:18.670623Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:18.435892Z"
     },
     "tags": []
    },
@@ -502,11 +419,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:55:56.123029Z",
-     "iopub.status.busy": "2022-04-04T23:55:56.122804Z",
-     "iopub.status.idle": "2022-04-04T23:56:03.465465Z",
-     "shell.execute_reply": "2022-04-04T23:56:03.464878Z",
-     "shell.execute_reply.started": "2022-04-04T23:55:56.123004Z"
+     "iopub.execute_input": "2022-04-25T18:04:22.377060Z",
+     "iopub.status.busy": "2022-04-25T18:04:22.376784Z",
+     "iopub.status.idle": "2022-04-25T18:04:22.780792Z",
+     "shell.execute_reply": "2022-04-25T18:04:22.779946Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:22.377037Z"
     },
     "tags": []
    },
@@ -551,11 +468,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:56:03.467001Z",
-     "iopub.status.busy": "2022-04-04T23:56:03.466750Z",
-     "iopub.status.idle": "2022-04-04T23:56:10.209465Z",
-     "shell.execute_reply": "2022-04-04T23:56:10.208807Z",
-     "shell.execute_reply.started": "2022-04-04T23:56:03.466974Z"
+     "iopub.execute_input": "2022-04-25T18:04:24.126312Z",
+     "iopub.status.busy": "2022-04-25T18:04:24.126034Z",
+     "iopub.status.idle": "2022-04-25T18:04:24.273835Z",
+     "shell.execute_reply": "2022-04-25T18:04:24.273387Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:24.126290Z"
     },
     "tags": []
    },
@@ -598,11 +515,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:56:10.210187Z",
-     "iopub.status.busy": "2022-04-04T23:56:10.210012Z",
-     "iopub.status.idle": "2022-04-04T23:56:24.081506Z",
-     "shell.execute_reply": "2022-04-04T23:56:24.080916Z",
-     "shell.execute_reply.started": "2022-04-04T23:56:10.210163Z"
+     "iopub.execute_input": "2022-04-25T18:04:25.270032Z",
+     "iopub.status.busy": "2022-04-25T18:04:25.269761Z",
+     "iopub.status.idle": "2022-04-25T18:04:25.563583Z",
+     "shell.execute_reply": "2022-04-25T18:04:25.563161Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:25.270010Z"
     },
     "tags": []
    },
@@ -650,11 +567,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:56:24.082472Z",
-     "iopub.status.busy": "2022-04-04T23:56:24.082227Z",
-     "iopub.status.idle": "2022-04-04T23:56:35.397420Z",
-     "shell.execute_reply": "2022-04-04T23:56:35.396741Z",
-     "shell.execute_reply.started": "2022-04-04T23:56:24.082446Z"
+     "iopub.execute_input": "2022-04-25T18:04:27.084714Z",
+     "iopub.status.busy": "2022-04-25T18:04:27.084441Z",
+     "iopub.status.idle": "2022-04-25T18:04:27.391437Z",
+     "shell.execute_reply": "2022-04-25T18:04:27.391029Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:27.084690Z"
     },
     "tags": []
    },
@@ -710,11 +627,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:56:35.398387Z",
-     "iopub.status.busy": "2022-04-04T23:56:35.398143Z",
-     "iopub.status.idle": "2022-04-04T23:56:52.486224Z",
-     "shell.execute_reply": "2022-04-04T23:56:52.485665Z",
-     "shell.execute_reply.started": "2022-04-04T23:56:35.398361Z"
+     "iopub.execute_input": "2022-04-25T18:04:29.508917Z",
+     "iopub.status.busy": "2022-04-25T18:04:29.508641Z",
+     "iopub.status.idle": "2022-04-25T18:04:29.903740Z",
+     "shell.execute_reply": "2022-04-25T18:04:29.903284Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:29.508894Z"
     },
     "tags": []
    },
@@ -769,11 +686,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:56:52.487198Z",
-     "iopub.status.busy": "2022-04-04T23:56:52.486963Z",
-     "iopub.status.idle": "2022-04-04T23:57:00.207285Z",
-     "shell.execute_reply": "2022-04-04T23:57:00.206699Z",
-     "shell.execute_reply.started": "2022-04-04T23:56:52.487172Z"
+     "iopub.execute_input": "2022-04-25T18:04:29.904671Z",
+     "iopub.status.busy": "2022-04-25T18:04:29.904463Z",
+     "iopub.status.idle": "2022-04-25T18:04:30.067343Z",
+     "shell.execute_reply": "2022-04-25T18:04:30.066890Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:29.904650Z"
     },
     "tags": []
    },
@@ -813,11 +730,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:57:00.208252Z",
-     "iopub.status.busy": "2022-04-04T23:57:00.208002Z",
-     "iopub.status.idle": "2022-04-04T23:57:05.325962Z",
-     "shell.execute_reply": "2022-04-04T23:57:05.325399Z",
-     "shell.execute_reply.started": "2022-04-04T23:57:00.208226Z"
+     "iopub.execute_input": "2022-04-25T18:04:31.560131Z",
+     "iopub.status.busy": "2022-04-25T18:04:31.559856Z",
+     "iopub.status.idle": "2022-04-25T18:04:31.778021Z",
+     "shell.execute_reply": "2022-04-25T18:04:31.777450Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:31.560107Z"
     },
     "tags": []
    },
@@ -859,11 +776,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:57:05.327792Z",
-     "iopub.status.busy": "2022-04-04T23:57:05.327522Z",
-     "iopub.status.idle": "2022-04-04T23:59:16.112792Z",
-     "shell.execute_reply": "2022-04-04T23:59:16.112212Z",
-     "shell.execute_reply.started": "2022-04-04T23:57:05.327766Z"
+     "iopub.execute_input": "2022-04-25T18:04:31.837049Z",
+     "iopub.status.busy": "2022-04-25T18:04:31.836737Z",
+     "iopub.status.idle": "2022-04-25T18:04:32.087767Z",
+     "shell.execute_reply": "2022-04-25T18:04:32.087208Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:31.837028Z"
     },
     "tags": []
    },
@@ -990,8 +907,11 @@
    "execution_count": null,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-04T23:59:16.113757Z",
-     "iopub.status.busy": "2022-04-04T23:59:16.113509Z"
+     "iopub.execute_input": "2022-04-25T18:04:34.838523Z",
+     "iopub.status.busy": "2022-04-25T18:04:34.838254Z",
+     "iopub.status.idle": "2022-04-25T18:04:34.960676Z",
+     "shell.execute_reply": "2022-04-25T18:04:34.960092Z",
+     "shell.execute_reply.started": "2022-04-25T18:04:34.838500Z"
     },
     "tags": []
    },
@@ -1033,19 +953,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b9413a73",
+   "metadata": {},
+   "source": [
+    "## Stopping the cluster\n",
+    "\n",
+    "When you're done using the parallel cluster you can shut it down with a single command. Note that since the cluster is running within the same Jupyter Server resource as the notebook, there is no change to what hardware is running after you stop it (since the resource is still on)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "id": "conditional-hindu",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-03-30T23:47:17.192025Z",
+     "iopub.status.busy": "2022-03-30T23:47:17.191835Z",
+     "iopub.status.idle": "2022-03-30T23:47:17.194517Z",
+     "shell.execute_reply": "2022-03-30T23:47:17.193814Z",
+     "shell.execute_reply.started": "2022-03-30T23:47:17.192006Z"
+    },
+    "tags": []
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "# command to stop the cluster\n",
+    "rc.cluster.stop_cluster_sync()"
+   ]
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "84d1d8d97458420fee614d334608cc9a296a01a4b7a7f960fcfd0f0633eb59fd"
+   "hash": "eb578bceb450296580617697e9f34b607f1f9864a45a33fefa2f3629db985dcc"
   },
   "kernelspec": {
-   "display_name": "SSH 10.30.3.4 Remote-Kernel",
+   "display_name": "SSH 10.30.3.217 Remote-Kernel",
    "language": "python",
    "name": "python3"
   },
@@ -1059,7 +1002,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates the bodo examples to use parquet files instead of csv files. This allows us to set `anon = True` when accessing the files so that the examples are not dependent on AWS credentials being set. 

Also added cluster stopping to two of the examples to be sure that running the examples sequentially doesn't create too many processes.

File locations were fixed on the back end.