### PR TITLE
add W&B examples to templates

### DIFF
--- a/.saturn/templates-enterprise.json
+++ b/.saturn/templates-enterprise.json
@@ -113,6 +113,12 @@
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/r-future.png",
       "weight": 1390,
       "recipe_path": "examples/r-future/.saturn/saturn.json"
+    },
+    {
+      "title": "Weights & Biases (Python)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/weights_and_biases.png",
+      "weight": 1900,
+      "recipe_path": "examples/wandb/.saturn/saturn.json"
     }
   ]
 }

--- a/.saturn/templates-hosted.json
+++ b/.saturn/templates-hosted.json
@@ -113,6 +113,12 @@
       "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/r-future.png",
       "weight": 1390,
       "recipe_path": "examples/r-future/.saturn/saturn.json"
+    },
+    {
+      "title": "Weights & Biases (Python)",
+      "thumbnail_image_url": "https://saturn-public-assets.s3.us-east-2.amazonaws.com/example-thumbnails/weights_and_biases.png",
+      "weight": 1900,
+      "recipe_path": "examples/wandb/.saturn/saturn.json"
     }
   ]
 }


### PR DESCRIPTION
Adds the weights and biases examples as template resources for both hosted and enterprise.