### PR TITLE
update to use saturn-rstudio instead of r-parallel

### DIFF
--- a/examples/r-future/.saturn/saturn.json
+++ b/examples/r-future/.saturn/saturn.json
@@ -1,10 +1,10 @@
 {
   "name": "example-r-future",
-  "image_uri": "public.ecr.aws/saturncloud/saturn-rstudio-parallel:2022.03.01",
+  "image_uri": "public.ecr.aws/saturncloud/saturn-rstudio:2022.04.01",
   "description": "Run parallel computing workloads using the future package.",
   "working_directory": "/home/jovyan/examples/examples/r-future",
   "extra_packages": {
-    "cran": "xgboost rsample Metrics"
+    "cran": "xgboost rsample Metrics targets furrr future visNetwork tarchetypes bs4Dash DT gt pingr shiny shinybusy shinyWidgets qs fst tictoc"
   },
   "start_script": "",
   "git_repositories": [

--- a/examples/r-future/r-furrr.Rmd
+++ b/examples/r-future/r-furrr.Rmd
@@ -158,7 +158,6 @@ Let's first try it with purrr to iterate through the various models.
 
 Actually, let's not -- it takes over 17 minutes to run this code.  
 ```{r purrr evaluation, eval=FALSE}
-
 ###################################################
 ## Don't actually run this - it takes forever... ##
 ###################################################


### PR DESCRIPTION
Changes the r-future example to use saturn-rstudio instead of saturn-rstudio-parallel.
The example uses v 2022.04.01 of the saturn-rstudio image to decrease startup time.
