### PR TITLE
change NYC taxi data to parquet

### DIFF
--- a/examples/dask/machine-learning-grid-search.ipynb
+++ b/examples/dask/machine-learning-grid-search.ipynb
@@ -110,9 +110,8 @@
    },
    "outputs": [],
    "source": [
-    "taxi = pd.read_csv(\n",
-    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-05.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi = pd.read_parquet(\n",
+    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-05.parquet\"\n",
     ")"
    ]
   },
@@ -310,9 +309,8 @@
    "source": [
     "import dask.dataframe as dd\n",
     "\n",
-    "taxi_dd = dd.read_csv(\n",
-    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2020-05.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi_dd = dd.read_parquet(\n",
+    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2020-05.parquet\",\n",
     "    storage_options={\"anon\": True},\n",
     "    assume_missing=True,\n",
     ")"
@@ -425,8 +423,11 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "b7848b2fbd737d4d16c30c2a265d9cb43a8b0508277d828bf32f61f61a6b4e46"
+  },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.2 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -440,7 +441,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,

--- a/examples/dask/machine-learning-grid-search.ipynb
+++ b/examples/dask/machine-learning-grid-search.ipynb
@@ -110,9 +110,7 @@
    },
    "outputs": [],
    "source": [
-    "taxi = pd.read_parquet(\n",
-    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-05.parquet\"\n",
-    ")"
+    "taxi = pd.read_parquet(\"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2020-05.parquet\")"
    ]
   },
   {

--- a/examples/dask/special-topics-rolling-average.ipynb
+++ b/examples/dask/special-topics-rolling-average.ipynb
@@ -58,7 +58,7 @@
    "source": [
     "After running the above command, it's recommended that you check on the Saturn Cloud resource page that the Dask cluster as fully online before continuing. Alternatively, you can use the command `client.wait_for_workers(3)` to halt the notebook execution until all three of the workers are ready.\n",
     "\n",
-    "Now load your data into a Dask DataFrame. Here we are loading data for csv file located in a public location hosted by Saturn Cloud. Using `read_csv` from Dask takes the same form as using that function from pandas."
+    "Now load your data into a Dask DataFrame. Here we are loading data for parquet file located in a public location hosted by Saturn Cloud. Using `read_parquet` from Dask takes the same form as using that function from pandas."
    ]
   },
   {
@@ -72,9 +72,8 @@
    "source": [
     "import dask.dataframe as dd\n",
     "\n",
-    "taxi = dd.read_csv(\n",
-    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-01.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi = dd.read_parquet(\n",
+    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-01.parquet\",\n",
     "    storage_options={\"anon\": True},\n",
     ").sample(frac=0.1, replace=False)"
    ]

--- a/examples/load-data/load-data-s3.ipynb
+++ b/examples/load-data/load-data-s3.ipynb
@@ -114,7 +114,7 @@
    "source": [
     "At this point, you can reference the `s3` handle and look at the contents of your S3 bucket as if it were a local file system. For examples, you can visit the <a href=\"https://s3fs.readthedocs.io/en/latest/#examples\" target='_blank' rel='noopener'>s3fs documentation</a> where they show multiple ways to interact with files like this.\n",
     "\n",
-    "#### Load a CSV Using pandas\n",
+    "#### Load a Parquet file using pandas\n",
     "This approach just uses routine pandas syntax."
    ]
   },
@@ -126,9 +126,9 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "file = \"nyc-tlc/trip data/yellow_tripdata_2019-01.csv\"\n",
+    "file = \"nyc-tlc/trip data/yellow_tripdata_2019-01.parquet\"\n",
     "with s3.open(file, mode=\"rb\") as f:\n",
-    "    df = pd.read_csv(f, parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"])"
+    "    df = pd.read_parquet(f)"
    ]
   },
   {
@@ -137,7 +137,7 @@
    "source": [
     "For small files, this approach will work fine. For large or multiple files, we recommend using Dask, as described next.\n",
     "\n",
-    "#### Load a CSV Using Dask\n",
+    "#### Load a Parquet file using Dask\n",
     "This syntax is the same as pandas, but produces a distributed data object."
    ]
   },
@@ -149,16 +149,16 @@
    "source": [
     "import dask.dataframe as dd\n",
     "\n",
-    "file = \"nyc-tlc/trip data/yellow_tripdata_2019-01.csv\"\n",
+    "file = \"nyc-tlc/trip data/yellow_tripdata_2019-01.parquet\"\n",
     "with s3.open(file, mode=\"rb\") as f:\n",
-    "    df = dd.read_csv(f, parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"])"
+    "    df = dd.read_parquet(f)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Load a Folder of CSVs Using Dask\n",
+    "#### Load a folder of Parquet files using Dask\n",
     "Dask can read and load a whole folder of files if they are formatted the same, using glob syntax."
    ]
   },
@@ -168,10 +168,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = s3.glob(\"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.csv\")\n",
-    "taxi = dd.read_csv(\n",
+    "files = s3.glob(\"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.parquet\")\n",
+    "taxi = dd.read_parquet(\n",
     "    files,\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
     "    storage_options={\"anon\": False},\n",
     "    assume_missing=True,\n",
     ")"

--- a/examples/prefect/03-prefect-resource-manager.ipynb
+++ b/examples/prefect/03-prefect-resource-manager.ipynb
@@ -158,9 +158,8 @@
    "source": [
     "@task\n",
     "def read():\n",
-    "    taxi = dd.read_csv(\n",
-    "        \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "    taxi = dd.read_parquet(\n",
+    "        \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.parquet\"\n",
     "    )\n",
     "    df2 = taxi[taxi.passenger_count > 1]\n",
     "    df3 = df2.groupby(\"VendorID\").passenger_count.std()\n",

--- a/examples/rapids-comparison/comparison.ipynb
+++ b/examples/rapids-comparison/comparison.ipynb
@@ -64,7 +64,7 @@
    },
    "outputs": [],
    "source": [
-    "!curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv > data.csv"
+    "!curl https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.parquet > data.parquet"
    ]
   },
   {
@@ -95,11 +95,8 @@
     "import pandas as pd\n",
     "from sklearn.ensemble import RandomForestClassifier as RFCPU\n",
     "\n",
-    "with timing(\"CPU: CSV Load\"):\n",
-    "    taxi_cpu = pd.read_csv(\n",
-    "        \"data.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
-    "    )\n",
+    "with timing(\"CPU: Parquet Load\"):\n",
+    "    taxi_cpu = pd.read_parquet(\"data.parquet\")\n",
     "\n",
     "X_cpu = taxi_cpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].fillna(-1)\n",
     "y_cpu = taxi_cpu[\"tip_amount\"] > 1\n",
@@ -138,11 +135,8 @@
     "import cudf\n",
     "from cuml.ensemble import RandomForestClassifier as RFGPU\n",
     "\n",
-    "with timing(\"GPU: CSV Load\"):\n",
-    "    taxi_gpu = cudf.read_csv(\n",
-    "        \"data.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
-    "    )\n",
+    "with timing(\"GPU: Parquet Load\"):\n",
+    "    taxi_gpu = cudf.read_parquet(\"data.parquet\")\n",
     "\n",
     "X_gpu = taxi_gpu[[\"PULocationID\", \"DOLocationID\", \"passenger_count\"]].astype(\"float32\").fillna(-1)\n",
     "y_gpu = (taxi_gpu[\"tip_amount\"] > 1).astype(\"int32\")\n",
@@ -201,8 +195,8 @@
    },
    "outputs": [],
    "source": [
-    "df[df.task == \"CSV Load\"].plot(\n",
-    "    title=\"CSV Load\",\n",
+    "df[df.task == \"Parquet Load\"].plot(\n",
+    "    title=\"Parquet Load\",\n",
     "    kind=\"bar\",\n",
     "    x=\"Hardware\",\n",
     "    y=\"Seconds\",\n",
@@ -284,9 +278,8 @@
    "outputs": [],
    "source": [
     "with timing(\"GPU + Dask: Random Forest (12x the data)\"):\n",
-    "    taxi_dask = dask_cudf.read_csv(\n",
-    "        \"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.csv\",\n",
-    "        parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "    taxi_dask = dask_cudf.read_parquet(\n",
+    "        \"s3://nyc-tlc/trip data/yellow_tripdata_2019-*.parquet\",\n",
     "        storage_options={\"anon\": True},\n",
     "        assume_missing=True,\n",
     "    )\n",

--- a/examples/rapids/01-rapids-single-gpu.ipynb
+++ b/examples/rapids/01-rapids-single-gpu.ipynb
@@ -81,9 +81,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi = cudf.read_csv(\n",
-    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi = cudf.read_parquet(\n",
+    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-01.parquet\"\n",
     ")"
    ]
   },
@@ -281,9 +280,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_test = cudf.read_csv(\n",
-    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-02.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi_test = cudf.read_parquet(\n",
+    "    \"https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2019-02.parquet\"\n",
     ")"
    ]
   },

--- a/examples/rapids/02-rapids-gpu-cluster.ipynb
+++ b/examples/rapids/02-rapids-gpu-cluster.ipynb
@@ -133,9 +133,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi = dask_cudf.read_csv(\n",
-    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-01.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi = dask_cudf.read_parquet(\n",
+    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-01.parquet\",\n",
     "    storage_options={\"anon\": True},\n",
     "    assume_missing=True,\n",
     ").persist()\n",
@@ -333,9 +332,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "taxi_test = dask_cudf.read_csv(\n",
-    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-02.csv\",\n",
-    "    parse_dates=[\"tpep_pickup_datetime\", \"tpep_dropoff_datetime\"],\n",
+    "taxi_test = dask_cudf.read_parquet(\n",
+    "    \"s3://nyc-tlc/trip data/yellow_tripdata_2019-02.parquet\",\n",
     "    storage_options={\"anon\": True},\n",
     "    assume_missing=True,\n",
     ").persist()\n",


### PR DESCRIPTION
The NYC taxi data converted to Parquet on 5/13/2022, so all examples need to be updated to `read_parquet` instead of `read_csv`.