### PR TITLE
Prefix flow name with username for uniqueness

### DIFF
--- a/examples/prefect/03-prefect-resource-manager.ipynb
+++ b/examples/prefect/03-prefect-resource-manager.ipynb
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with Flow(\"prefect-resource-manager\") as flow:\n",
+    "with Flow(f\"{SATURN_USERNAME}-prefect-resource-manager\") as flow:\n",
     "    with _DaskCluster(n_workers=3) as client:  # noqa: F841\n",
     "        a = read()"
    ]


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

This is one potential fix for a timing bug in the integration-tests. Occasionally the prefect-resource-manger test will fail because it registers the flow using the notebook then almost immediately queries for the flow's ID by name in a separate script. Since the flow's name is always the same sometimes the prefect API responds with the ID for the previous version instead of the newest one, and then creating a new flow run fails because that version has been archived ([example](https://github.com/saturncloud/release-images/runs/6731084102?check_suite_focus=true))

The other notebooks in this example don't have this problem because they prefix flow names with the username, and in integration-tests the usernames contain UUIDs. So the flow is always unique.

Outside of the context of integration-tests, it seems sensible to have the same naming pattern across all of the flows created in this example.