### PR TITLE
Install libtiff5 for comet example

### DIFF
--- a/examples/comet/.saturn/saturn.json
+++ b/examples/comet/.saturn/saturn.json
@@ -4,6 +4,7 @@
   "description": "Track and compare your ML models using Comet",
   "working_directory": "/home/jovyan/examples/examples/comet",
   "extra_packages": {
+    "apt": "libtiff5",
     "pip": "comet_ml",
     "conda": "pytorch torchvision cpuonly -c pytorch",
     "use_mamba": true


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->
```
ImportError                               Traceback (most recent call last)
File ~/examples/examples/comet/comet-example-32f3d06e-5f73-490e-ab83-d75b727054a9.py:31
     29 import torch
     30 import torch.nn as nn
---> 31 import torchvision.datasets as dsets
     32 import torchvision.transforms as transforms
     33 from torch.autograd import Variable

File /opt/saturncloud/envs/saturn/lib/python3.9/site-packages/torchvision/__init__.py:6
      3 from modulefinder import Module
      5 import torch
----> 6 from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils
      8 from .extension import _HAS_OPS
     10 try:

File /opt/saturncloud/envs/saturn/lib/python3.9/site-packages/torchvision/datasets/__init__.py:1
----> 1 from ._optical_flow import FlyingChairs, FlyingThings3D, HD1K, KittiFlow, Sintel
      2 from ._stereo_matching import (
      3     CarlaStereo,
      4     CREStereo,
   (...)
     12     SintelStereo,
     13 )
     14 from .caltech import Caltech101, Caltech256

File /opt/saturncloud/envs/saturn/lib/python3.9/site-packages/torchvision/datasets/_optical_flow.py:10
      8 import numpy as np
      9 import torch
---> 10 from PIL import Image
     12 from ..io.image import _read_png_16
     13 from .utils import _read_pfm, verify_str_arg

File /opt/saturncloud/envs/saturn/lib/python3.9/site-packages/PIL/Image.py:103
     94 MAX_IMAGE_PIXELS = int(1024 * 1024 * 1024 // 4 // 3)
     97 try:
     98     # If the _imaging C module is not present, Pillow will not load.
     99     # Note that other modules should not refer to _imaging directly;
    100     # import Image and use the Image.core variable instead.
    101     # Also note that Image.core is not a publicly documented interface,
    102     # and should be considered private and subject to change.
--> 103     from . import _imaging as core
    105     if __version__ != getattr(core, "PILLOW_VERSION", None):
    106         msg = (
    107             "The _imaging extension was built for another version of Pillow or PIL:\n"
    108             f"Core version: {getattr(core, 'PILLOW_VERSION', None)}\n"
    109             f"Pillow version: {__version__}"
    110         )

ImportError: libtiff.so.5: cannot open shared object file: No such file or directory
```