### PR TITLE
Update typing extensions

### DIFF
--- a/examples/comet/.saturn/saturn.json
+++ b/examples/comet/.saturn/saturn.json
@@ -5,7 +5,7 @@
   "working_directory": "/home/jovyan/examples/examples/comet",
   "extra_packages": {
     "apt": "libtiff5",
-    "pip": "comet_ml",
+    "pip": "comet_ml 'typing_extensions==4.7.1'",
     "conda": "pytorch torchvision cpuonly -c pytorch",
     "use_mamba": true
   },


### PR DESCRIPTION
<!-- What is this change, and why is it needed? -->

Pytorch imports requires more recent version of typing_extensions